### PR TITLE
Update requirements to include python JMESPath

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ansible
 yamllint
-python-jmespath
+jmespath

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ansible
 yamllint
+python-jmespath


### PR DESCRIPTION
Reason:
https://github.com/oVirt/ovirt-ansible/blob/master/roles/ovirt-image-template/tasks/main.yml#L46