### PR TITLE
Add ability to pass high_availability flag to VM

### DIFF
--- a/roles/ovirt-vm-infra/README.md
+++ b/roles/ovirt-vm-infra/README.md
@@ -39,6 +39,7 @@ The `profile` dictionary can contain following attributes:
 | ssh_key            | UNDEF                 | SSH key to be deployed to VM                 |
 | domain             | UNDEF                 | The domain of the VM                         |
 | root_password      | UNDEF                 | root password of the VM                      |
+| high_availability  | UNDEF                 | Whether or not the node should be set highly available |
 
 The item in `disks` list can contain following attributes:
 

--- a/roles/ovirt-vm-infra/tasks/main.yml
+++ b/roles/ovirt-vm-infra/tasks/main.yml
@@ -21,6 +21,7 @@
       name: "{{ item.name }}"
       memory: "{{ item.profile.memory }}"
       cpu_cores: "{{ item.profile.cores }}"
+      high_availability: "{{ item.profile.high_availability | default(omit) }}"
       cloud_init:
         host_name: "{{ item.name }}.{{ item.profile.domain | default(omit) }}"
         authorized_ssh_keys: "{{ item.profile.ssh_key | default('') }}"


### PR DESCRIPTION
Should be a simple passing of a flag. I copied the sense of the root_password entry so the default is set to omit.