### PR TITLE
introduce import template from glance

### DIFF
--- a/roles/ovirt-import-template-from-glance/.travis.yml
+++ b/roles/ovirt-import-template-from-glance/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/roles/ovirt-import-template-from-glance/README.md
+++ b/roles/ovirt-import-template-from-glance/README.md
@@ -1,0 +1,63 @@
+# TODO
+oVirt import template from glance
+==================================
+
+This role imports disk from glance as template, add nic to template and copy its disks to storage domains.
+
+Requirements
+------------
+
+ * oVirt Python SDK version 4
+ * Ansible version 2.3
+
+Role Variables
+--------------
+
+The value of item in `external_templates_from_glance` list can contain following parameters:
+
+| Name            | Default value  | Description                           |
+|-----------------|----------------|---------------------------------------|
+| name            | UNDEF          | Name of the the template to manage.   |
+| image_provider  | UNDEF          | When state is imported this parameter specifies the name of the image provider to be used. |
+| image_disk      | UNDEF          | When state is imported and image_provider is used this parameter specifies the name of disk to be imported as template. |
+| storage_domain  | UNDEF          | When state is imported this parameter specifies the name of the destination data storage domain. |
+| cluster         | UNDEF          | Name of the cluster, where template should be created/imported. |
+
+More information about storages parameters can be found [here](http://docs.ansible.com/ansible/latest/ovirt_templates_module.html).
+
+
+Dependencies
+------------
+
+No.
+
+Example Playbook
+----------------
+
+```yaml
+- name: oVirt infra
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars:
+    external_templates_from_glance:
+      - name: template_name
+        state: imported
+        image_provider: myglance
+        image_disk: rhel7.4
+        storage_domain: my_storage_domain
+        cluster: my_cluster
+
+    destination_domains:
+      - my_storage_domain
+      - my_storage_domain_2
+
+  roles:
+    - ovirt-import-template-from-glance
+```
+
+License
+-------
+
+Apache License 2.0

--- a/roles/ovirt-import-template-from-glance/defaults/main.yml
+++ b/roles/ovirt-import-template-from-glance/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for roles/ovirt-import-template-from-glance

--- a/roles/ovirt-import-template-from-glance/handlers/main.yml
+++ b/roles/ovirt-import-template-from-glance/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for roles/ovirt-import-template-from-glance

--- a/roles/ovirt-import-template-from-glance/meta/main.yml
+++ b/roles/ovirt-import-template-from-glance/meta/main.yml
@@ -1,0 +1,21 @@
+galaxy_info:
+  author: Tareq Alayan
+  description: Role to import disk as template from glance in oVirt.
+  company: Red Hat, Inc.
+
+  license: Apache License 2.0
+
+  min_ansible_version: 2.3
+
+  platforms:
+  - name: EL
+    versions:
+    - 7
+  - name: Fedora
+    versions:
+    - 24
+    - 25
+
+  galaxy_tags: [ovirt, rhv, rhev, virtualization]
+
+dependencies: []

--- a/roles/ovirt-import-template-from-glance/tasks/main.yml
+++ b/roles/ovirt-import-template-from-glance/tasks/main.yml
@@ -1,0 +1,65 @@
+---
+#################################################
+# import template from glance and add nic
+#################################################
+- name: Import templates from glance
+  ovirt_templates:
+    auth: "{{ ovirt_auth }}"
+    state: imported
+    name: "{{ item.name }}"
+    image_provider: "{{ item.image_provider }}"
+    image_disk: "{{ item.image_disk }}"
+    storage_domain: "{{ item.storage_domain }}"
+    cluster: "{{ item.cluster }}"
+    fetch_nested: True
+  register: templates
+  with_items:
+    - "{{ external_templates | default([]) }}"
+  tags:
+    - external_templates
+
+- name: test add nic to template
+  ovirt_nics:
+    auth: "{{ ovirt_auth }}"
+    state: present
+    template: "{{ item.name }}"
+    name: nic1
+    profile: ovirtmgmt
+    network: ovirtmgmt
+  with_items:
+    - "{{ external_templates | default([]) }}"
+  tags:
+    - external_template
+    - add_nic
+
+- name: get imported templates facts
+  ovirt_templates_facts:
+    auth: "{{ ovirt_auth }}"
+    pattern: name="{{ item.name }}"*
+    fetch_nested: true
+  register: imported_templates
+  with_items:
+    - "{{ external_templates | default([]) }}"
+  tags:
+    - external_templates
+
+- name: debug
+  debug:
+    msg: "{{ item }}"
+    verbosity: 2
+  with_items:
+    - "{{ imported_templates.results }}"
+
+- name: copy template disks to all storage domain defined in destination_domains
+  ovirt_disks:
+    auth: "{{ ovirt_auth }}"
+    id: "{{ item[0].ansible_facts.ovirt_templates[0].disk_attachments[0].id[0] }}"
+    storage_domains:  "{{ item[1] }}"
+    fetch_nested: true
+    timeout: 600
+  with_nested:
+    - "{{ imported_templates.results }}"
+    - "{{ destination_domains }}"
+  tags:
+    - external_templates
+    - copy_template_disks

--- a/roles/ovirt-import-template-from-glance/tests/inventory
+++ b/roles/ovirt-import-template-from-glance/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/roles/ovirt-import-template-from-glance/tests/test.yml
+++ b/roles/ovirt-import-template-from-glance/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - roles/ovirt-import-template-from-glance

--- a/roles/ovirt-import-template-from-glance/vars/main.yml
+++ b/roles/ovirt-import-template-from-glance/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for roles/ovirt-import-template-from-glance


### PR DESCRIPTION
This role is meant to be used by the automation infra in which:
 - import disks from glance as templates
 - add nic to the templates
 - copy the template's disks to the destination domains defined.