### PR TITLE
ovirt-image-template: add glance as disk source

### DIFF
--- a/roles/ovirt-image-template/README.md
+++ b/roles/ovirt-image-template/README.md
@@ -1,7 +1,7 @@
 oVirt Image Template
 ====================
 
-The `ovirt-image-template` role downloads a QCOW2 image from a specified URL and creates a template from it.
+The `ovirt-image-template` role creates a template from external image. Currently the disk can be an image in Glance external provider or QCOW2 image.
 
 Requirements
 ------------
@@ -15,7 +15,7 @@ Role Variables
 --------------
 
 | Name               | Default value         |                            |
-|--------------------|-----------------------|----------------------------| 
+|--------------------|-----------------------|----------------------------|
 | qcow_url           | UNDEF                 | The URL of the QCOW2 image. |
 | image_path         | /tmp/ovirt_image_data | Path where the QCOW2 image will be downloaded to. |
 | template_cluster   | Default               | Name of the cluster where template must be created. |
@@ -28,6 +28,8 @@ Role Variables
 | template_disk_interface | virtio           | Interface of the template disk. |
 | template_timeout   | 600                   | Amount of time to wait for the template to be created. |
 | template_nics      | {name: nic1, profile_name: ovirtmgmt, interface: virtio} | List of dictionaries that specify the NICs of template. |
+| glance_image_provider        | UNDEF            | Name of the glance image provider.                    |
+| glance_image            | UNDEF               | This parameter specifies the name of disk in glance provider to be imported as template. |
 
 Dependencies
 ------------
@@ -39,7 +41,7 @@ Example Playbook
 
 ```yaml
 ---
-- name: oVirt image template
+- name: Create a template from qcow
   hosts: localhost
   connection: local
   gather_facts: false
@@ -51,6 +53,30 @@ Example Playbook
     engine_cafile: /etc/pki/ovirt-engine/ca.pem
 
     qcow_url: https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2
+    template_cluster: production
+    template_name: centos7_template
+    template_memory: 4GiB
+    template_cpu: 2
+    template_disk_size: 10GiB
+    template_disk_storage: mydata
+
+  roles:
+    - ovirt-image-template
+
+
+- name: Create a template from a disk stored in glance
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars:
+    engine_url: https://ovirt-engine.example.com/ovirt-engine/api
+    engine_user: admin@internal
+    engine_password: 123456
+    engine_cafile: /etc/pki/ovirt-engine/ca.pem
+
+    glance_image_provider: qe-infra-glance
+    glance_image: rhel7.4_ovirt4.2_guest_disk
     template_cluster: production
     template_name: centos7_template
     template_memory: 4GiB

--- a/roles/ovirt-image-template/meta/main.yml
+++ b/roles/ovirt-image-template/meta/main.yml
@@ -1,6 +1,6 @@
 galaxy_info:
   author: Ondra Machacek
-  description: Role to create template from qcow2 image.
+  description: Role to create template from external image.
   company: Red Hat, Inc.
 
   license: Apache License 2.0

--- a/roles/ovirt-image-template/tasks/glance_image.yml
+++ b/roles/ovirt-image-template/tasks/glance_image.yml
@@ -1,0 +1,46 @@
+---
+- block:
+  - name: Login to oVirt
+    ovirt_auth:
+      url: "{{ engine_url }}"
+      username: "{{ engine_user }}"
+      password: "{{ engine_password }}"
+      ca_file: "{{ engine_cafile | default(omit) }}"
+      insecure: "{{ engine_insecure | default(true) }}"
+    when: ovirt_auth is undefined
+    register: loggedin
+    tags:
+      - always
+
+  - name: Fetch storages
+    ovirt_storage_domains_facts:
+      auth: "{{ ovirt_auth }}"
+    tags:
+      - ovirt-template-image
+
+  - name: Find data domain
+    set_fact:
+      disk_storage_domain: "{{ ovirt_storage_domains|json_query(the_query)|list|first}}"
+    vars:
+      the_query: "[?type=='data']"
+    tags:
+      - ovirt-template-image
+
+  - name: Import templates from glance
+    ovirt_templates:
+      auth: "{{ ovirt_auth }}"
+      state: imported
+      name: "{{ template_name }}"
+      image_provider: "{{ glance_image_provider }}"
+      image_disk: "{{ glance_image }}"
+      storage_domain: "{{ template_disk_storage | default(disk_storage_domain.name) }}"
+      cluster: "{{ template_cluster }}"
+
+  always:
+    - name: Logout from oVirt
+      ovirt_auth:
+        state: absent
+        ovirt_auth: "{{ ovirt_auth }}"
+      when: not loggedin.skipped | default(false)
+      tags:
+        - always

--- a/roles/ovirt-image-template/tasks/main.yml
+++ b/roles/ovirt-image-template/tasks/main.yml
@@ -1,120 +1,13 @@
 ---
-- name: Download the qcow image
-  get_url:
-    url: "{{ qcow_url }}"
-    dest: "{{ image_path }}"
-  register: downloaded
-  tags:
-    - ovirt-template-image
-
-- name: Check file type
-  command: "/usr/bin/file {{ image_path | quote }}"
-  changed_when: false
-  register: filetype
-  tags:
-    - ovirt-template-image
-
-- name: Fail if image is not qcow
+- name: Fail when invalid parameters
   fail:
-    msg: "The downloaded file is not valid QCOW file."
-  when: '"QCOW" not in filetype.stdout'
-  tags:
-    - ovirt-template-image
+    msg: "You must either specify qcow2_url or glance_image"
+  when: "glance_image is defined and qcow2_url is defined"
 
-- block:
-  - name: Login to oVirt
-    ovirt_auth:
-      url: "{{ engine_url }}"
-      username: "{{ engine_user }}"
-      password: "{{ engine_password }}"
-      ca_file: "{{ engine_cafile | default(omit) }}"
-      insecure: "{{ engine_insecure | default(true) }}"
-    when: ovirt_auth is undefined
-    register: loggedin
-    tags:
-      - always
+- name: Glance image
+  include: glance_image.yml
+  when: "glance_image is defined"
 
-  - name: Fetch storages
-    ovirt_storage_domains_facts:
-      auth: "{{ ovirt_auth }}"
-    when: template_disk_storage is undefined
-    tags:
-      - ovirt-template-image
-  
-  - name: Find data domain
-    set_fact:
-      disk_storage_domain: "{{ ovirt_storage_domains|json_query(the_query)|list|first}}"
-    when: template_disk_storage is undefined
-    vars:
-      the_query: "[?type=='data']"
-    tags:
-      - ovirt-template-image
-  
-  - name: Check if template already exists
-    ovirt_templates_facts:
-      auth: "{{ ovirt_auth }}"
-      pattern: "name={{ template_name }}"
-    tags:
-      - ovirt-template-image
-  
-  - name: Deploy the qcow image to oVirt engine
-    ovirt_disks:
-      auth: "{{ ovirt_auth }}"
-      name: "{{ template_disk_name | default(template_name) }}"
-      interface: "{{ template_disk_format | default('virtio') }}"
-      size: "{{ template_disk_size}}"
-      format: "{{  template_disk_interface | default('cow') }}"
-      image_path: "{{ image_path }}"
-      storage_domain: "{{ template_disk_storage | default(disk_storage_domain.name) }}"
-      force: "{{ ovirt_templates | length == 0 }}"
-    register: ovirt_disk
-    when: ovirt_templates | length == 0
-    tags:
-      - ovirt-template-image
-  
-  - name: Create vm
-    ovirt_vms:
-      auth: "{{ ovirt_auth }}"
-      name: "{{ vm_name }}"
-      state: stopped
-      cluster: "{{ template_cluster }}"
-      memory: "{{ template_memory }}"
-      cpu_cores: "{{ template_cpu }}"
-      operating_system: "{{ template_operating_system }}"
-      type: server
-      disks:
-        - id: "{{ ovirt_disk.id }}"
-          bootable: true
-      nics: "{{ template_nics }}"
-    when: ovirt_templates | length == 0
-    tags:
-      - ovirt-template-image
-  
-  - name: Create template
-    ovirt_templates:
-      auth: "{{ ovirt_auth }}"
-      name: "{{ template_name }}"
-      vm: "{{ vm_name }}"
-      timeout: "{{ template_timeout }}"
-    when: ovirt_templates | length == 0
-    tags:
-      - ovirt-template-image
-  
-  always:
-    - name: Remove vm
-      ovirt_vms:
-        auth: "{{ ovirt_auth }}"
-        state: absent
-        name: "{{ vm_name }}"
-      when: ovirt_templates | length == 0
-      tags:
-        - ovirt-template-image
-
-    - name: Logout from oVirt
-      ovirt_auth:
-        state: absent
-        ovirt_auth: "{{ ovirt_auth }}"
-      when: not loggedin.skipped | default(false)
-      tags:
-        - always
-
+- name: QCOW2 image
+  include: qcow2_image.yml
+  when: "qcow2_url is defined"

--- a/roles/ovirt-image-template/tasks/qcow2_image.yml
+++ b/roles/ovirt-image-template/tasks/qcow2_image.yml
@@ -1,0 +1,119 @@
+---
+- name: Download the qcow image
+  get_url:
+    url: "{{ qcow_url }}"
+    dest: "{{ image_path }}"
+  register: downloaded
+  tags:
+    - ovirt-template-image
+
+- name: Check file type
+  command: "/usr/bin/file {{ image_path | quote }}"
+  changed_when: false
+  register: filetype
+  tags:
+    - ovirt-template-image
+
+- name: Fail if image is not qcow
+  fail:
+    msg: "The downloaded file is not valid QCOW file."
+  when: '"QCOW" not in filetype.stdout'
+  tags:
+    - ovirt-template-image
+
+- block:
+  - name: Login to oVirt
+    ovirt_auth:
+      url: "{{ engine_url }}"
+      username: "{{ engine_user }}"
+      password: "{{ engine_password }}"
+      ca_file: "{{ engine_cafile | default(omit) }}"
+      insecure: "{{ engine_insecure | default(true) }}"
+    when: ovirt_auth is undefined
+    register: loggedin
+    tags:
+      - always
+
+  - name: Fetch storages
+    ovirt_storage_domains_facts:
+      auth: "{{ ovirt_auth }}"
+    when: template_disk_storage is undefined
+    tags:
+      - ovirt-template-image
+
+  - name: Find data domain
+    set_fact:
+      disk_storage_domain: "{{ ovirt_storage_domains|json_query(the_query)|list|first}}"
+    when: template_disk_storage is undefined
+    vars:
+      the_query: "[?type=='data']"
+    tags:
+      - ovirt-template-image
+
+  - name: Check if template already exists
+    ovirt_templates_facts:
+      auth: "{{ ovirt_auth }}"
+      pattern: "name={{ template_name }}"
+    tags:
+      - ovirt-template-image
+
+  - name: Deploy the qcow image to oVirt engine
+    ovirt_disks:
+      auth: "{{ ovirt_auth }}"
+      name: "{{ template_disk_name | default(template_name) }}"
+      interface: "{{ template_disk_format | default('virtio') }}"
+      size: "{{ template_disk_size}}"
+      format: "{{  template_disk_interface | default('cow') }}"
+      image_path: "{{ image_path }}"
+      storage_domain: "{{ template_disk_storage | default(disk_storage_domain.name) }}"
+      force: "{{ ovirt_templates | length == 0 }}"
+    register: ovirt_disk
+    when: ovirt_templates | length == 0
+    tags:
+      - ovirt-template-image
+
+  - name: Create vm
+    ovirt_vms:
+      auth: "{{ ovirt_auth }}"
+      name: "{{ vm_name }}"
+      state: stopped
+      cluster: "{{ template_cluster }}"
+      memory: "{{ template_memory }}"
+      cpu_cores: "{{ template_cpu }}"
+      operating_system: "{{ template_operating_system }}"
+      type: server
+      disks:
+        - id: "{{ ovirt_disk.id }}"
+          bootable: true
+      nics: "{{ template_nics }}"
+    when: ovirt_templates | length == 0
+    tags:
+      - ovirt-template-image
+
+  - name: Create template
+    ovirt_templates:
+      auth: "{{ ovirt_auth }}"
+      name: "{{ template_name }}"
+      vm: "{{ vm_name }}"
+      timeout: "{{ template_timeout }}"
+    when: ovirt_templates | length == 0
+    tags:
+      - ovirt-template-image
+
+  always:
+    - name: Remove vm
+      ovirt_vms:
+        auth: "{{ ovirt_auth }}"
+        state: absent
+        name: "{{ vm_name }}"
+      when: ovirt_templates | length == 0
+      tags:
+        - ovirt-template-image
+
+    - name: Logout from oVirt
+      ovirt_auth:
+        state: absent
+        ovirt_auth: "{{ ovirt_auth }}"
+      when: not loggedin.skipped | default(false)
+      tags:
+        - always


### PR DESCRIPTION
Before this you could create a template from a qcow file located in some
webserver.
Now you can also create a template froma disk that is located in glance.

see:
https://github.com/oVirt/ovirt-ansible/issues/29