### PR TITLE
ovirt-clusters: set ksm & balooning to be True

### DIFF
--- a/roles/ovirt-clusters/README.md
+++ b/roles/ovirt-clusters/README.md
@@ -59,8 +59,8 @@ Possible `profile` options are `development` and `production`, their default val
 
 | Parameter                         | Value              |
 |-----------------------------------|--------------------|
-| ballooning                        | false              |
-| ksm                               | false              |
+| ballooning                        | true               |
+| ksm                               | true               |
 | host_reason                       | true               |
 | vm_reason                         | true               |
 | memory_policy                     | disabled           |

--- a/roles/ovirt-clusters/vars/main.yml
+++ b/roles/ovirt-clusters/vars/main.yml
@@ -12,8 +12,8 @@ profiles:
 
   production:
      description: Production cluster
-     ballooning: false
-     ksm: false
+     ballooning: true
+     ksm: true
      host_reason: true
      vm_reason: true
      memory_policy: disabled


### PR DESCRIPTION
fixes: https://github.com/oVirt/ovirt-ansible/issues/45