### PR TITLE
Shorten VDSM RPM version fetch

### DIFF
--- a/roles/ovirt-host-deploy-firewalld/tasks/main.yml
+++ b/roles/ovirt-host-deploy-firewalld/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Fetch info about VDSM
-  command: bash -c "rpm -qi vdsm | grep -oE 'Version\\s+:\\s+[0-9\\.]+' | awk '{print $3}'"
+  command: bash -c "rpm -q vdsm --qf '%{VERSION}'"
   changed_when: false
   register: vdsm_version
 


### PR DESCRIPTION
You could use RPM query format to get the version, no need for grep and awk.