### PR TITLE
Add python-jmespath dependency to RPM

### DIFF
--- a/ovirt-ansible-roles.spec.in
+++ b/ovirt-ansible-roles.spec.in
@@ -19,6 +19,7 @@ BuildArch:      noarch
 Url:            http://www.ovirt.org
 
 Requires: ansible >= 2.3.0
+Requires: python-jmespath
 
 %description
 Collection of Ansible roles to ease the management and automation of the oVirt engine.


### PR DESCRIPTION
We need to add jmespath dependency since we use `json_query` which is build upon jmepath.