### PR TITLE
Add python2-jmespath dependency to RPM

### DIFF
--- a/ovirt-ansible-roles.spec.in
+++ b/ovirt-ansible-roles.spec.in
@@ -18,6 +18,7 @@ BuildArch:      noarch
 Url:            http://www.ovirt.org
 
 Requires: ansible >= 2.3.0
+Requires: python2-jmespath
 
 %description
 Collection of Ansible roles to ease the management and automation of the oVirt engine.


### PR DESCRIPTION
We need to add `python2-jmespath` dependency since we use `json_query` which is build upon `jmepath`. 