### PR TITLE
ovirt-cluster-upgrade: Don't run check_for upgrade if not needed

### DIFF
--- a/roles/ovirt-cluster-upgrade/README.md
+++ b/roles/ovirt-cluster-upgrade/README.md
@@ -20,6 +20,7 @@ Role Variables
 | upgrade_timeout         | 1200                  | Timeout in seconds to wait for host to be upgraded. |
 | host_statuses           | [UP]                  | List of host statuses. If a host is in any of the specified statuses then it will be upgraded. |
 | host_names              | [\*]                  | List of host names to be upgraded.        |
+| check_upgrade           | false                 | If true, run check_for_upgrade action on all hosts before executing upgrade on them. If false, run upgrade only for hosts with available upgrades and ignore all other hosts. |
 
 Dependencies
 ------------

--- a/roles/ovirt-cluster-upgrade/defaults/main.yml
+++ b/roles/ovirt-cluster-upgrade/defaults/main.yml
@@ -2,6 +2,7 @@
 stop_pinned_to_host_vms: false
 upgrade_timeout: 1200
 cluster_name: Default
+check_upgrade: false
 host_statuses:
   - up
 host_names:

--- a/roles/ovirt-cluster-upgrade/tasks/main.yml
+++ b/roles/ovirt-cluster-upgrade/tasks/main.yml
@@ -15,7 +15,7 @@
   - name: Get hosts
     ovirt_hosts_facts:
       auth: "{{ ovirt_auth }}"
-      pattern: "cluster={{ cluster_name | mandatory }} update_available=true {{ host_names | map('regex_replace', '(.*)', 'name=\\1') | list | join(' or ') }} {{ host_statuses | map('regex_replace', '(.*)', 'status=\\1') | list | join(' or ') }}"
+      pattern: "cluster={{ cluster_name | mandatory }} {{ check_upgrade | ternary('', 'update_available=true') }} {{ host_names | map('regex_replace', '(.*)', 'name=\\1') | list | join(' or ') }} {{ host_statuses | map('regex_replace', '(.*)', 'status=\\1') | list | join(' or ') }}"
   
   - name: Check if there are hosts to be updated
     debug:
@@ -106,7 +106,6 @@
       - name: Print info about host which was updated
         debug:
           msg: "Following hosts was successfully updated: {{ succeed_host_names }}"
-        when: "succeed_host_names | length > 0"
 
       - name: Fail the playbook, if some hosts wasn't updated
         fail:

--- a/roles/ovirt-cluster-upgrade/tasks/upgrade.yml
+++ b/roles/ovirt-cluster-upgrade/tasks/upgrade.yml
@@ -6,12 +6,14 @@
       auth: "{{ ovirt_auth }}"
       name: "{{ item.name }}"
       state: upgraded
+      check_upgrade: "{{ check_upgrade }}"
       timeout: "{{ upgrade_timeout }}"
     register: host_upgraded
 
   - name: Append host name to list of upgraded hosts
     set_fact:
       succeed_host_names: "{{ succeed_host_names }} + [ '{{ item.name }}' ]"
+    when: host_upgraded.changed
 
   rescue:
     - name: Report issues


### PR DESCRIPTION
This PR add new `check_upgrade` parameter.

If this parameter is `true`, we will fetch all host according to user's pattern, even host which don't report available updates and then check for upgrade action, before performing actual upgrade action.

If this parameter is `false`, we only fetch hosts which has update_available, and we don't check for upgrade.