### PR TITLE
Support DR with oVirt

### DIFF
--- a/examples/disaster_recovery_vars.yml
+++ b/examples/disaster_recovery_vars.yml
@@ -1,0 +1,96 @@
+---
+dr_sites_primary_url: "http://mlipchuk.usersys.redhat.com:8080/ovirt-engine/api"
+dr_sites_primary_username: "admin@internal"
+dr_sites_primary_ca_file: "/home/mlipchuk/ovirt-share/etc/pki/ovirt-engine/ca.pem"
+
+dr_sites_secondary_url: "http://10.35.0.140:8080/ovirt-engine/api"
+dr_sites_secondary_username: "admin@internal"
+dr_sites_secondary_ca_file: "/home/mlipchuk/ovirt-share/etc/pki/ovirt-engine/ca.pem"
+
+dr_import_storages:
+    - dr_domain_type: "nfs"
+      dr_master_domain: "True"
+      dr_primary_address: "10.35.16.43"
+      dr_primary_path: "/export/data_test7"
+      dr_primary_dc_name: "Prod"
+      dr_primary_name: "data7"
+      dr_secondary_address: "10.35.1.68"
+      dr_secondary_path: "/home/export/data2"
+      dr_secondary_dc_name: "Recovery"
+      dr_secondary_name: "data2"
+
+    - dr_domain_type: "nfs"
+      dr_master_domain: "False"
+      dr_primary_name: "data6"
+      dr_primary_address: "10.35.16.43"
+      dr_primary_path: "/export/data_test6"
+      dr_primary_dc_name: "Prod"
+      dr_secondary_name: "data"
+      dr_secondary_address: "10.35.1.68"
+      dr_secondary_path: "/home/export/data1"
+      dr_secondary_dc_name: "Recovery"
+
+    - dr_domain_type: "iscsi"
+      dr_master_domain: "False"
+      dr_primary_id: "aa92cc71-1b88-4998-a755-970ef8a638ea"
+      dr_primary_address: "10.35.16.55"
+      dr_primary_target: ["iqn.2015-07.com.mlipchuk1.redhat:444"]
+      dr_primary_dc_name: "Prod"
+      dr_primary_name: "scsi2"
+      dr_secondary_id: "ccccf47b-ff77-4660-bf07-2809a750adb6"
+      dr_secondary_address: "10.35.0.222"
+      dr_secondary_target: ["iqn.2015-07.com.recovery.redhat:444"]
+      dr_secondary_dc_name: "Recovery"
+      dr_secondary_name: "scsi2"
+
+# Mapping for cluster
+dr_cluster_mappings:
+    - primary_name: cluster_prod
+      secondary_name: cluster_recovery
+
+# Mapping for affinity group
+dr_affinity_group_mappings:
+    - primary_name: "primary_affinity"
+      secondary_name: "secondary_affinity"
+
+# Mapping for affinity label
+dr_affinity_label_mappings:
+    - primary_name: "label_prod"
+      secondary_name: "label_recovery"
+
+# Mapping for domain
+dr_domain_mappings:
+    - primary_name: "new-authz"
+      secondary_name: "internal-authz"
+
+# Mapping for roles
+dr_role_mappings:
+    - primary_name: "VmMananger"
+      secondary_name: "NeverMnd"
+
+# Mapping for vnic profile
+dr_network_mappings:
+    - primary_network_name: "ovirtmgmt"
+      primary_profile_name: "ovirtmgmt"
+      primary_profile_id: "e368cbd4-59d9-4a7e-86c1-e405c916a836"
+      secondary_network_name: "ovirtmgmt"
+      secondary_profile_name: "ovirtmgmt"
+      secondary_profile_id: "e368cbd4-59d9-4a7e-86c1-e405c916a836"
+
+# Mapping for direct LUN disks
+dr_lun_mappings:
+    - primary_logical_unit_id: "360014056a2be431c0fd46c4bdce92b66"
+      primary_logical_unit_address: "10.35.16.55"
+      primary_logical_unit_port: 3260
+      primary_logical_unit_portal: "1"
+      primary_logical_unit_username: ""
+      primary_logical_unit_password: ""
+      primary_logical_unit_target: "iqn.2015-07.com.mlipchuk1.redhat:444"
+      secondary_storage_type: "iscsi"
+      secondary_logical_unit_id: "36001405961a7f95e6aa461b8dba53052"
+      secondary_logical_unit_address: "10.35.0.222"
+      secondary_logical_unit_port: 3260
+      secondary_logical_unit_portal: "1"
+      secondary_logical_unit_username: ""
+      secondary_logical_unit_password: ""
+      secondary_logical_unit_target: "iqn.2015-07.com.recovery.redhat:444"

--- a/examples/dr_ovirt_setup.yml
+++ b/examples/dr_ovirt_setup.yml
@@ -1,0 +1,9 @@
+---
+- name: Setup oVirt environment
+  hosts: localhost
+  connection: local
+  vars_files:
+     - ovirt_passwords.yml
+     - disaster_recovery_vars.yml
+  roles:
+     - {role: ovirt-disaster-recovery}

--- a/roles/ovirt-disaster-recovery/defaults/main.yml
+++ b/roles/ovirt-disaster-recovery/defaults/main.yml
@@ -1,0 +1,14 @@
+# Indicate whether to ignore errors on clean engine setup.
+dr_ignore_error_clean: "no"
+
+# Indicate whether to ignore errors on recover.
+dr_ignore_error_recover: "yes"
+
+# Indicate whether to use the partial import flag when registering VMs and Templates.
+dr_partial_import: "True"
+
+# Indicate the default target host to be used in the play
+dr_target_host: "primary"
+
+# Indicate the default sourece map o be used in the play
+dr_source_map: "secondary"

--- a/roles/ovirt-disaster-recovery/tasks/clean/remove_disks.yml
+++ b/roles/ovirt-disaster-recovery/tasks/clean/remove_disks.yml
@@ -1,0 +1,5 @@
+- name: Remove disk
+  ovirt_disks:
+      state: absent
+      id: "{{ disk.id }}"
+      auth: "{{ ovirt_auth }}"

--- a/roles/ovirt-disaster-recovery/tasks/clean/remove_domain.yml
+++ b/roles/ovirt-disaster-recovery/tasks/clean/remove_domain.yml
@@ -1,0 +1,11 @@
+# If we get the exception "Cannot deactivate Master Data Domain while there are running tasks on its Data Center."
+# We should wait for some time and try again
+- name: Remove storage domain
+  ovirt_storage_domains:
+      state: absent
+      id: "{{ storage.id }}"
+      name: "{{ storage.name }}"
+      auth: "{{ ovirt_auth }}"
+      host: "{{ host }}"
+      destroy: "{{ dr_force }}"
+      data_center: "{{ sp_uuid }}"

--- a/roles/ovirt-disaster-recovery/tasks/clean/remove_domain_process.yml
+++ b/roles/ovirt-disaster-recovery/tasks/clean/remove_domain_process.yml
@@ -1,0 +1,39 @@
+# TODO: Check what happens when we force remove unattached storage domain (probably should add a default empty GUID as a data center
+# Answer: When we force remove an unattached storage domain, ansible tries to move it to maintenance and detach it first, although it might be that this storage domain is already detached and has no related data center, therefor the move to maintenance will fail
+
+# We set an initial value for sp_uuid since this task is being called
+# multiple times from the main task and sp_uuid is stateful.
+- name: Set default boolean value for sp_uuid
+  set_fact: sp_uuid=True
+
+- name: Detached storage domain - Set sp_uuid with empty GUID
+  set_fact: sp_uuid="00000000-0000-0000-0000-000000000000"
+  when: storage.data_centers is not defined
+
+- name: Detached storage domain - Fetch active host for remove
+  ovirt_hosts_facts:
+    pattern: "status=up"
+    auth: "{{ ovirt_auth }}"
+  when: storage.data_centers is not defined
+
+- name: Attached storage domain - Fetch active host for remove
+  ovirt_hosts_facts:
+    pattern: "status=up and storage={{ storage.name }}"
+    auth: "{{ ovirt_auth }}"
+  when: storage.data_centers is defined
+
+# If sp_uuid is still initiated with the default boolean value,
+# that means that there is a data center which the storage domain is attached to it.
+- name: Attached storage domain - Set sp_uuid
+  set_fact: sp_uuid="{{ storage.data_centers[0].id }}"
+  when: sp_uuid
+
+- name: Remove storage domain with no force
+  include_tasks: roles/ovirt-disaster-recovery/tasks/clean/remove_domain.yml host={{ ovirt_hosts[0].id }}
+  when: "ovirt_hosts is defined and ovirt_hosts|length > 0 and not force"
+
+- name: Force remove storage domain
+  include_tasks: roles/ovirt-disaster-recovery/tasks/clean/remove_domain.yml host="00000000-0000-0000-0000-000000000000"
+  #storage={{ storage }} host={{ ovirt_hosts[0] }} sp_uuid=sp_uuid
+  when: "force"
+

--- a/roles/ovirt-disaster-recovery/tasks/clean/remove_vms.yml
+++ b/roles/ovirt-disaster-recovery/tasks/clean/remove_vms.yml
@@ -1,0 +1,5 @@
+- name: Remove diskless VMs
+  ovirt_vms:
+      state: absent
+      name: "{{ vm.name }}"
+      auth: "{{ ovirt_auth }}"

--- a/roles/ovirt-disaster-recovery/tasks/clean/shutdown_vms.yml
+++ b/roles/ovirt-disaster-recovery/tasks/clean/shutdown_vms.yml
@@ -1,0 +1,8 @@
+- name: Shutdown VMs
+  ovirt_vms:
+      state: stopped
+      name: "{{ vms.name }}"
+      force: True
+      wait: False
+      auth: "{{ ovirt_auth }}"
+

--- a/roles/ovirt-disaster-recovery/tasks/clean/update_ovf_store.yml
+++ b/roles/ovirt-disaster-recovery/tasks/clean/update_ovf_store.yml
@@ -1,0 +1,5 @@
+- name: update OVF store for storage domain
+  ovirt_storage_domains:
+      state: update_ovf_store
+      name: "{{ storage.name }}"
+      auth: "{{ ovirt_auth }}"

--- a/roles/ovirt-disaster-recovery/tasks/clean_engine.yml
+++ b/roles/ovirt-disaster-recovery/tasks/clean_engine.yml
@@ -1,0 +1,117 @@
+- block:
+    - name: Obtain SSO token
+      ovirt_auth:
+          url: "{{ vars['dr_sites_' + dr_source_map + '_url'] }}"
+          username: "{{ vars['dr_sites_' + dr_source_map + '_username'] }}"
+          password: "{{ vars['dr_sites_' + dr_source_map + '_password'] }}"
+          ca_file: "{{ vars['dr_sites_' + dr_source_map + '_ca_file'] }}"
+
+    # Get all the running VMs and shut them down
+    - name: Fetch VMs in the setup
+      ovirt_vms_facts:
+          pattern:  status != down
+          auth: "{{ ovirt_auth }}"
+
+    - include_tasks: roles/ovirt-disaster-recovery/tasks/clean/shutdown_vms.yml vms={{ item }}
+      with_items: "{{ ovirt_vms }}"
+
+    - name: Update OVF_STORE disks for active storage domain
+      ovirt_storage_domains_facts:
+          pattern:  status = active and type != glance
+          auth: "{{ ovirt_auth }}"
+
+    - include_tasks: roles/ovirt-disaster-recovery/tasks/clean/update_ovf_store.yml storage={{ item }}
+      with_items:
+          - "{{ ovirt_storage_domains }}"
+
+    # We do not supoport export storage domain
+    # TODO: Export storage domain should be handled by an independant task which will clean the meta data.
+    # We first remove all the non master storage domain.
+    - name: Fetch valid storage domains for detach
+      ovirt_storage_domains_facts:
+          pattern:  status = active or status = maintenance or status = unattached and type != glance
+          auth: "{{ ovirt_auth }}"
+
+    - name: Set force remove flag to false
+      set_fact: dr_force=False
+
+    - include_tasks: roles/ovirt-disaster-recovery/tasks/clean/remove_domain_process.yml storage={{ item }}
+      with_items:
+          - "{{ ovirt_storage_domains }}"
+      when: "not item.master"
+
+    # We use inactive filter only at the end, since we are not sure if there were any storage domains
+    # which became inactive on the process or if there were any on the beginning.
+    - name: Fetch invalid storage domains to remove
+      ovirt_storage_domains_facts:
+          # TODO: Should check also about Cinder
+          pattern: status != active and type != glance
+          auth: "{{ ovirt_auth }}"
+
+    - name: Set force remove flag to true
+      set_fact: dr_force=True
+
+    - include_tasks: roles/ovirt-disaster-recovery/tasks/clean/remove_domain_process.yml storage={{ item }}
+      with_items:
+          - "{{ ovirt_storage_domains }}"
+      when: "not item.master"
+
+    # Try to remove the master storage domains, if we fail we will try later to force remove all
+    # inactive master domains.
+    - name: Fetch valid storage domains for detach master
+      ovirt_storage_domains_facts:
+          pattern:  status = active or status = maintenance
+          auth: "{{ ovirt_auth }}"
+
+    - name: Set force remove flag to false
+      set_fact: dr_force=False
+
+    - include_tasks: roles/ovirt-disaster-recovery/tasks/clean/remove_domain_process.yml storage={{ item }}
+      with_items:
+          - "{{ ovirt_storage_domains }}"
+      when: "item.master"
+
+    # If by any chance the master storage domain is inactive we force remove it.
+    - name: Set force remove flag to true
+      set_fact: dr_force=True
+
+    - name: Fetch invalid storage domains to remove master
+      ovirt_storage_domains_facts:
+          pattern: status != active and type != glance
+          auth: "{{ ovirt_auth }}"
+
+    - include_tasks: roles/ovirt-disaster-recovery/tasks/clean/remove_domain_process.yml storage={{ item }}
+      with_items:
+          - "{{ ovirt_storage_domains }}"
+
+    - name: Fetch leftover storage domains
+      ovirt_storage_domains_facts:
+          pattern: type != glance
+          auth: "{{ ovirt_auth }}"
+
+    # Remove direct LUN disks
+    - name: Fetch leftover direct LUN disks in the setup
+      ovirt_disk_facts:
+          pattern: alias != OVF_STORE
+          auth: "{{ ovirt_auth }}"
+
+    - include_tasks: roles/ovirt-disaster-recovery/tasks/clean/remove_disks.yml disk={{ item }}
+      with_items: "{{ ovirt_disks }}"
+
+    # Remove VMs without disks only if there are no data storage domains left in the setup
+    - name: Fetch leftover VMs in the setup
+      ovirt_vms_facts:
+          auth: "{{ ovirt_auth }}"
+      when: "ovirt_storage_domains | length == 0"
+
+    - include_tasks: roles/ovirt-disaster-recovery/tasks/clean/remove_vms.yml vm={{ item }}
+      with_items: "{{ ovirt_vms }}"
+
+  # Default value is set in role defaults
+  ignore_errors: "{{ dr_ignore_error_clean }}"
+- always:
+    - name: Revoke the SSO token
+      ovirt_auth:
+          state: absent
+          ovirt_auth: "{{ ovirt_auth }}"
+

--- a/roles/ovirt-disaster-recovery/tasks/main.yml
+++ b/roles/ovirt-disaster-recovery/tasks/main.yml
@@ -1,0 +1,23 @@
+- block:
+    - include_tasks: roles/ovirt-disaster-recovery/tasks/unregister_entities.yml
+      tags:
+          - fail_back
+
+    - include_tasks: roles/ovirt-disaster-recovery/tasks/clean_engine.yml
+      tags:
+          - fail_back
+          - clean_engine
+
+    - pause:
+          prompt: "Please update once the destination storage domains are ready to be used for recovery"
+      tags:
+          - fail_back
+
+    - include_tasks: roles/ovirt-disaster-recovery/tasks/recover_engine.yml
+      tags:
+          - fail_over
+          - fail_back
+
+    - include_tasks: roles/ovirt-disaster-recovery/tasks/run_unregistered_entities.yml
+      tags:
+          - fail_back

--- a/roles/ovirt-disaster-recovery/tasks/recover/add_block_domain.yml
+++ b/roles/ovirt-disaster-recovery/tasks/recover/add_block_domain.yml
@@ -1,0 +1,51 @@
+# TODO: Add to the documentation:
+# On each operation we fetch a running host for the transaction and not using any
+# pre-fetched default host since the each operation might have a different DC.
+- set_fact:
+    storage_name: "{{ storage.name }}"
+
+- name: Fetch active host in data center
+  ovirt_hosts_facts:
+      pattern: "status=up and datacenter={{ storage.DC_name }}"
+      auth: "{{ ovirt_auth }}"
+
+- name: Login to iSCSI targets
+  ovirt_hosts:
+      state: iscsilogin
+      name: "{{ ovirt_hosts[0].name }}"
+      auth: "{{ ovirt_auth }}"
+      iscsi:
+          username: "{{ storage.username }}"
+          password: "{{ storage.password }}"
+          address: "{{ storage.address }}"
+          target: "{{ scsi_target }}"
+          # Make port to be optional
+          port: "{{  storage.port }}"
+  with_items:
+     - "{{ storage.target }}"
+  loop_control:
+     loop_var: scsi_target
+
+- name: Import block storage domain
+  ovirt_storage_domains:
+      state: imported
+      id: "{{ storage.id }}"
+      name: "{{ storage.name }}"
+      host: "{{ ovirt_hosts[0].name }}"
+      auth: "{{ ovirt_auth }}"
+      data_center: "{{ storage.DC_name }}"
+      # TODO: For import block there is no need for the iscsi parameters
+      iscsi:
+          username: "{{ storage,username }}"
+          password: "{{ storage.password }}"
+          address: "{{ storage.address }}"
+          # We use target since state imported in ovirt_storage_domains.py creates a storage domain
+          # which calls login, therfore we must have a target althout the targets were already connected before.
+          # Therefore passing the first target in the list as a transient target.
+          target: "{{ scsi_target }}"
+  with_items:
+     - "{{ storage.target }}"
+  loop_control:
+     loop_var: scsi_target
+
+

--- a/roles/ovirt-disaster-recovery/tasks/recover/add_domain.yml
+++ b/roles/ovirt-disaster-recovery/tasks/recover/add_domain.yml
@@ -1,0 +1,38 @@
+- ovirt_hosts_facts:
+      pattern: "status=up and datacenter={{ storage['dr_' + dr_target_host + '_dc_name'] }}"
+      auth: "{{ ovirt_auth }}"
+
+- include_tasks: roles/ovirt-disaster-recovery/tasks/recover/add_nfs_domain.yml
+  with_items:
+    - "{{ storage }}"
+  when: "storage.dr_domain_type == 'nfs'"
+  loop_control:
+      loop_var: nfs_storage
+
+- include_tasks: roles/ovirt-disaster-recovery/tasks/recover/add_glusterfs_domain.yml
+  with_items:
+    - "{{ storage }}"
+  when: "storage.dr_domain_type == 'gluster'"
+  loop_control:
+      loop_var: gluster_storage
+
+- include_tasks: roles/ovirt-disaster-recovery/tasks/recover/add_posixfs_domain.yml
+  with_items:
+    - "{{ storage }}"
+  when: "storage.dr_domain_type == 'posixfs'"
+  loop_control:
+      loop_var: posix_storage
+
+- include_tasks: roles/ovirt-disaster-recovery/tasks/recover/add_iscsi_domain.yml
+  with_items:
+    - "{{ storage }}"
+  when: "storage.dr_domain_type == 'iscsi'"
+  loop_control:
+      loop_var: iscsi_storage
+
+- include_tasks: roles/ovirt-disaster-recovery/tasks/recover/add_fcp_domain.yml
+  with_items:
+    - "{{ storage }}"
+  when: "storage.dr_domain_type == 'fcp'"
+  loop_control:
+      loop_var: fcp_storage

--- a/roles/ovirt-disaster-recovery/tasks/recover/add_fcp_domain.yml
+++ b/roles/ovirt-disaster-recovery/tasks/recover/add_fcp_domain.yml
@@ -1,0 +1,9 @@
+- name: Import FCP storage domain
+  ovirt_storage_domains:
+      state: imported
+      id: "{{ fcp_storage['dr_' + dr_target_host + '_id'] }}"
+      name: "{{ fcp_storage['dr_' + dr_target_host + '_name']|default('') }}"
+      host: "{{ ovirt_hosts[0].name }}"
+      auth: "{{ ovirt_auth }}"
+      data_center: "{{ fcp_storage['dr_' + dr_target_host + '_dc_name'] }}"
+      fcp: {}

--- a/roles/ovirt-disaster-recovery/tasks/recover/add_glusterfs_domain.yml
+++ b/roles/ovirt-disaster-recovery/tasks/recover/add_glusterfs_domain.yml
@@ -1,0 +1,9 @@
+- name: Add Gluster storage domain
+  ovirt_storage_domains:
+      name: "{{ gluster_storage['dr_' + dr_target_host + '_name'] }}"
+      host: "{{ ovirt_hosts[0].name }}"
+      data_center: "{{ gluster_storage['dr_' + dr_target_host + '_dc_name'] }}"
+      auth: "{{ ovirt_auth }}"
+      glusterfs:
+          path: "{{ gluster_storage['dr_' + dr_target_host + '_path'] }}"
+          address: "{{ gluster_storage['dr_' + dr_target_host + '_address'] }}"

--- a/roles/ovirt-disaster-recovery/tasks/recover/add_iscsi_domain.yml
+++ b/roles/ovirt-disaster-recovery/tasks/recover/add_iscsi_domain.yml
@@ -1,0 +1,40 @@
+# TODO: Add support for connect to multiple targets with the same LUN.
+# Every connect should be done using a different ip
+- name: Login to iSCSI targets
+  ovirt_hosts:
+      state: iscsilogin
+      name: "{{ ovirt_hosts[0].name }}"
+      auth: "{{ ovirt_auth }}"
+      iscsi:
+          username: "{{ iscsi_storage['dr_' + dr_target_host + '_username']|default('') }}"
+          password: "{{ iscsi_storage['dr_' + dr_target_host + '_password']|default('') }}"
+          address: "{{ iscsi_storage['dr_' + dr_target_host + '_address'] }}"
+          target: "{{ dr_target }}"
+          # Make port to be optional
+          port: "{{ iscsi_storage['dr_' + dr_target_host + '_port']|default('') }}"
+  with_items:
+     - "{{ iscsi_storage['dr_' + dr_target_host + '_target'] }}"
+  loop_control:
+     loop_var: dr_target
+
+- name: Import iSCSI storage domain
+  ovirt_storage_domains:
+      state: imported
+      id: "{{ iscsi_storage['dr_' + dr_target_host + '_id'] }}"
+      name: "{{ iscsi_storage['dr_' + dr_target_host + '_name']|default('') }}"
+      host: "{{ ovirt_hosts[0].name }}"
+      auth: "{{ ovirt_auth }}"
+      data_center: "{{ iscsi_storage['dr_' + dr_target_host + '_dc_name'] }}"
+      # TODO: For import iSCSI there is no need for the iscsi parameters
+      iscsi:
+          username: "{{ iscsi_storage['dr_' + dr_target_host + '_username']|default('') }}"
+          password: "{{ iscsi_storage['dr_' + dr_target_host + '_password']|default('') }}"
+          address: "{{ iscsi_storage['dr_' + dr_target_host + '_address'] }}"
+          # We use target since state imported in ovirt_storage_domains.py creates a storage domain
+          # which calls login, therfore we must have a target althout the targets were already connected before.
+          # Therefore passing the first target in the list as a transient target.
+          target: "{{ dr_target }}"
+  with_items:
+     - "{{ iscsi_storage['dr_' + dr_target_host + '_target'] }}"
+  loop_control:
+     loop_var: dr_target

--- a/roles/ovirt-disaster-recovery/tasks/recover/add_nfs_domain.yml
+++ b/roles/ovirt-disaster-recovery/tasks/recover/add_nfs_domain.yml
@@ -1,0 +1,9 @@
+- name: Add NFS storage domain
+  ovirt_storage_domains:
+      name: "{{ nfs_storage['dr_' + dr_target_host + '_name'] }}"
+      host: "{{ ovirt_hosts[0].name }}"
+      data_center: "{{ nfs_storage['dr_' + dr_target_host + '_dc_name'] }}"
+      auth: "{{ ovirt_auth }}"
+      nfs:
+          path: "{{ nfs_storage['dr_' + dr_target_host + '_path'] }}"
+          address: "{{ nfs_storage['dr_' + dr_target_host + '_address'] }}"

--- a/roles/ovirt-disaster-recovery/tasks/recover/add_posixfs_domain.yml
+++ b/roles/ovirt-disaster-recovery/tasks/recover/add_posixfs_domain.yml
@@ -1,0 +1,10 @@
+- name: Add posix storage domain
+  ovirt_storage_domains:
+      name: "{{ posix_storage['dr_' + dr_target_host + '_name'] }}"
+      host: "{{ ovirt_hosts[0].name }}"
+      data_center: "{{ posix_storage['dr_' + dr_target_host + '_dc_name'] }}"
+      auth: "{{ ovirt_auth }}"
+      posixfs:
+          path: "{{ posix_storage['dr_' + dr_target_host + '_path'] }}"
+          address: "{{ posix_storage['dr_' + dr_target_host + '_address'] }}"
+

--- a/roles/ovirt-disaster-recovery/tasks/recover/register_templates.yml
+++ b/roles/ovirt-disaster-recovery/tasks/recover/register_templates.yml
@@ -1,0 +1,33 @@
+- name: Fetch unregistered Templates from storage domain
+  ovirt_storage_templates_facts:
+      nested_attributes: "id"
+      unregistered: True
+      storage_domain: "{{ storage.name }}"
+      auth: "{{ ovirt_auth }}"
+
+- name: Register unregistered Template
+  ovirt_templates:
+      state: registered
+      storage_domain: "{{ storage.name }}"
+      id: "{{ unreg_template.id }}"
+      allow_partial_import: "{{ dr_partial_import }}"
+      auth: "{{ ovirt_auth }}"
+      cluster_mappings: "{{ dr_cluster_map }}"
+      domain_mappings: "{{ dr_domain_map }}"
+      vnic_profile_mappings:  "{{ dr_network_map }}"
+      role_mappings: "{{ dr_role_map }}"
+
+      # TODO: We should set a flag
+      # - fail: msg="The execution has failed because of errors."
+      #  when: flag == "failed"
+      #
+      #  - name: Set flag
+      #  set_fact: flag = failed
+      #  when: "'FAILED' in command_result.stderr"
+  # The main task already declared ignore errors so that might bredundant to put it here
+  # ignore_errors: "{{ ignore | default(yes) }}"
+  with_items: "{{ ovirt_storage_templates }}"
+  # We use loop_control so storage.name will not be overriden by the nested loop.
+  loop_control:
+      loop_var: unreg_template
+

--- a/roles/ovirt-disaster-recovery/tasks/recover/register_vms.yml
+++ b/roles/ovirt-disaster-recovery/tasks/recover/register_vms.yml
@@ -1,0 +1,35 @@
+- name: Fetch unregistered VMs from storage domain
+  ovirt_storage_vms_facts:
+      nested_attributes: "id"
+      unregistered: True
+      storage_domain: "{{ storage.name }}"
+      auth: "{{ ovirt_auth }}"
+
+- name: Set unregistered VMs
+  set_fact:
+      unreg_vms: "{{ unreg_vms|default([]) }} + {{ ovirt_storage_vms }}"
+
+# TODO: We should filter out vms which were already exists in the setup (diskless VMs)
+- name: Register unregistered VM
+  ovirt_vms:
+      state: registered
+      storage_domain: "{{ storage.name }}"
+      id: "{{ unreg_vm.id }}"
+      auth: "{{ ovirt_auth }}"
+      allow_partial_import: "{{ dr_partial_import }}"
+      cluster_mappings: "{{ dr_cluster_map }}"
+      domain_mappings: "{{ dr_domain_map }}"
+      role_mappings: "{{ dr_role_map }}"
+      affinity_group_mappings: "{{ dr_affinity_group_map }}"
+      affinity_label_mappings: "{{ dr_affinity_label_map }}"
+      vnic_profile_mappings:  "{{ dr_network_map }}"
+      lun_mappings: "{{ dr_lun_map }}"
+
+  # The main task already declared ignore errors so that might be redundant to put it here
+  # ignore_errors: "{{ ignore | default(yes) }}"
+  with_items: "{{ ovirt_storage_vms }}"
+  # We use loop_control so storage.name will not be overriden by the nested loop.
+  loop_control:
+      loop_var: unreg_vm
+
+

--- a/roles/ovirt-disaster-recovery/tasks/recover/run_vms.yml
+++ b/roles/ovirt-disaster-recovery/tasks/recover/run_vms.yml
@@ -1,0 +1,6 @@
+- name: Run VMs
+  ovirt_vms:
+      state: running
+      name: "{{ vms.name }}"
+      wait: False
+      auth: "{{ ovirt_auth }}"

--- a/roles/ovirt-disaster-recovery/tasks/recover_engine.yml
+++ b/roles/ovirt-disaster-recovery/tasks/recover_engine.yml
@@ -1,0 +1,163 @@
+- block:
+    - name: Obtain SSO token
+      ovirt_auth:
+          url: "{{ vars['dr_sites_' + dr_target_host + '_url'] }}"
+          username: "{{ vars['dr_sites_' + dr_target_host + '_username'] }}"
+          password: "{{ vars['dr_sites_' + dr_target_host + '_password'] }}"
+          ca_file: "{{ vars['dr_sites_' + dr_target_host + '_ca_file'] }}"
+
+    # TODO: We should add a validation task that will validate whether
+    # all the hosts in the other site (primary or secondary) could not be connected
+    # and also set a timer that will wait at least 180 seconds until the first 
+    # attach will take place. We should do that to prevent sanlock failure with acquire
+    # lockspace. We should use a flag with default true whether to have thise check
+    # or not.
+
+    # TODO: What happens if master is failed to be attached,
+    # do we still want to continue and attach the other storage
+    # domain (which will make another storage domain as master instead).
+    - include_tasks: roles/ovirt-disaster-recovery/tasks/recover/add_domain.yml storage={{ item }}
+      with_items:
+        - "{{ dr_import_storages }}"
+      when: "item.dr_master_domain"
+
+    - include_tasks: roles/ovirt-disaster-recovery/tasks/recover/add_domain.yml storage={{ item }}
+      with_items:
+        - "{{ dr_import_storages }}"
+      when: "not item.dr_master_domain"
+
+    # Get all the active storage domains in the setup to register
+    # all the templates/VMs/Disks
+    - name: Fetching active storage domains
+      ovirt_storage_domains_facts:
+          pattern: "status=active"
+          auth: "{{ ovirt_auth }}"
+
+    - name: Set initial Maps
+      set_fact:
+          dr_cluster_map: "{{ [] }}"
+          dr_affinity_group_map: "{{ [] }}"
+          dr_affinity_label_map: "{{ [] }}"
+          dr_domain_map: "{{ [] }}"
+          dr_role_map: "{{ [] }}"
+          dr_lun_map: "{{ [] }}"
+          dr_network_map: "{{ [] }}"
+
+    - name: Set Cluster Map
+      set_fact:
+              dr_cluster_map: "{{ dr_cluster_map }} + {{ [
+              {
+                  'source_name': item[dr_source_map + '_name'] | default(''),
+                  'dest_name': item[dr_target_host + '_name'] | default('')
+              }
+          ] }}"
+      with_items: "{{ dr_cluster_mappings }}"
+      when: dr_cluster_mappings is not none
+
+    - name: Set Affinity Group Map
+      set_fact:
+              dr_affinity_group_map: "{{ dr_affinity_group_map }} + {{ [
+              {
+                  'source_name': item[dr_source_map + '_name'] | default(''),
+                  'dest_name': item[dr_target_host + '_name'] | default('')
+              }
+          ] }}"
+      with_items: "{{ dr_affinity_group_mappings }}"
+      when: dr_affinity_group_mappings is not none
+
+    - name: Set Network Map
+      set_fact:
+              dr_network_map: "{{ dr_network_map }} + {{ [
+              {
+                  'source_network_name': item[dr_source_map + '_network_name'] | default(''),
+                  'source_profile_name': item[dr_source_map + '_profile_name'] | default(''),
+                  'target_profile_id': item[dr_target_host + '_profile_id'] | default('')
+              }
+          ] }}"
+      with_items: "{{ dr_network_mappings }}"
+      when: dr_network_mappings is not none
+
+    - name: Set Affinity Label Map
+      set_fact:
+              dr_affinity_label_map: "{{ dr_affinity_label_map }} + {{ [
+              {
+                  'source_name': item[dr_source_map + '_name'] | default(''),
+                  'dest_name': item[dr_target_host + '_name'] | default('')
+              }
+          ] }}"
+      with_items: "{{ dr_affinity_label_mappings }}"
+      when: dr_affinity_label_mappings is not none
+
+    - name: Set aaa extensions Map
+      set_fact:
+              dr_domain_map: "{{ dr_domain_map }} + {{ [
+              {
+                  'source_name': item[dr_source_map + '_name'] | default(''),
+                  'dest_name': item[dr_target_host + '_name'] | default('')
+              }
+          ] }}"
+      with_items: "{{ dr_domain_mappings }}"
+      when: dr_domain_mappings is not none
+
+    - name: Set Role Map
+      set_fact:
+              dr_role_map: "{{ dr_role_map }} + {{ [
+              {
+                  'source_name': item[dr_source_map + '_name'] | default(''),
+                  'dest_name': item[dr_target_host + '_name'] | default('')
+              }
+          ] }}"
+      with_items: "{{ dr_role_mappings }}"
+      when: dr_role_mappings is not none
+
+    - name: Set Lun Map
+      set_fact:
+              dr_lun_map: "{{ dr_lun_map }} + {{ [
+              {
+                  'source_logical_unit_id': item[dr_source_map + '_logical_unit_id'] | default(''),
+                  'source_storage_type': item[dr_source_map + 'storage_type'] | default(''),
+                  'dest_logical_unit_id': item[dr_target_host + '_logical_unit_id'] | default(''),
+                  'dest_storage_type': item[dr_target_host + 'storage_type'] | default(''),
+                  'dest_logical_unit_address': item[dr_target_host + '_logical_unit_address'] | default(''),
+                  'dest_logical_unit_port': item[dr_target_host + '_logical_unit_port'] | default(''),
+                  'dest_logical_unit_portal': item[dr_target_host + '_logical_unit_portal'] | default(''),
+                  'dest_logical_unit_username': item[dr_target_host + '_logical_unit_username'] | default(''),
+                  'dest_logical_unit_password': item[dr_target_host + '_logical_unit_password'] | default(''),
+                  'dest_logical_unit_target': item[dr_target_host + '_logical_unit_target'] | default('')
+              }
+          ] }}"
+      with_items: "{{ dr_lun_mappings }}"
+      when: dr_lun_mappings is not none
+
+    # First register all the unregistered templates based on the
+    # active storage domains we fetched before.
+    # We register the Templates first since we might have
+    # VMs which are based on them
+    - include_tasks: roles/ovirt-disaster-recovery/tasks/recover/register_templates.yml storage={{ item }}
+      with_items:
+        - "{{ ovirt_storage_domains }}"
+
+    # Register all the unregistered VMs after we registerd
+    # all the templates from the active storage domains fetched before.
+    - include_tasks: roles/ovirt-disaster-recovery/tasks/recover/register_vms.yml storage={{ item }}
+      with_items:
+        - "{{ ovirt_storage_domains }}"
+
+    # Run all the high availability VMs.
+    - include_tasks: roles/ovirt-disaster-recovery/tasks/recover/run_vms.yml vms={{ item }}
+      with_items: "{{ unreg_vms }}"
+      when: item.status == 'up' and item.high_availability.enabled | bool
+
+    # Run all the rest of the VMs.
+    - include_tasks: roles/ovirt-disaster-recovery/tasks/recover/run_vms.yml vms={{ item }}
+      with_items: "{{ unreg_vms }}"
+      when: item.status == 'up' and not item.high_availability.enabled | bool
+
+  # Default value is set in role defaults
+  ignore_errors: "{{ dr_ignore_error_recover }}"
+
+- always:
+     - name: Revoke the SSO token
+       ovirt_auth:
+           state: absent
+           ovirt_auth: "{{ ovirt_auth }}"

--- a/roles/ovirt-disaster-recovery/tasks/run_unregistered_entities.yml
+++ b/roles/ovirt-disaster-recovery/tasks/run_unregistered_entities.yml
@@ -1,0 +1,23 @@
+- block:
+    - name: Obtain SSO token
+      ovirt_auth:
+          url: "{{ vars['dr_sites_' + dr_target_host + '_url'] }}"
+          username: "{{ vars['dr_sites_' + dr_target_host + '_username'] }}"
+          password: "{{ vars['dr_sites_' + dr_target_host + '_password'] }}"
+          ca_file: "{{ vars['dr_sites_' + dr_target_host + '_ca_file'] }}"
+
+    # Run all the high availability VMs.
+    - include_tasks: roles/ovirt-disaster-recovery/tasks/run_vms.yml vms={{ item }}
+      with_items: "{{ running_vms_fail_back }}"
+      when: item.high_availability.enabled | bool
+
+    - include_tasks: roles/ovirt-disaster-recovery/tasks/run_vms.yml vms={{ item }}
+      with_items: "{{ running_vms_fail_back }}"
+      when: not item.high_availability.enabled | bool
+
+  ignore_errors: "{{ dr_ignore_error_clean }}"
+- always:
+    - name: Revoke the SSO token
+      ovirt_auth:
+          state: absent
+          ovirt_auth: "{{ ovirt_auth }}"

--- a/roles/ovirt-disaster-recovery/tasks/unregister_entities.yml
+++ b/roles/ovirt-disaster-recovery/tasks/unregister_entities.yml
@@ -1,0 +1,25 @@
+- block:
+    - name: Obtain SSO token
+      ovirt_auth:
+          url: "{{ vars['dr_sites_' + dr_source_map + '_url'] }}"
+          username: "{{ vars['dr_sites_' + dr_source_map + '_username'] }}"
+          password: "{{ vars['dr_sites_' + dr_source_map + '_password'] }}"
+          ca_file: "{{ vars['dr_sites_' + dr_source_map + '_ca_file'] }}"
+
+    # Get all the running VMs and shut them down
+    - name: Fetch running VMs in the setup
+      ovirt_vms_facts:
+          pattern:  status = up
+          auth: "{{ ovirt_auth }}"
+
+    # TODO: Should be written to a file
+    - name: Define running VMs
+      set_fact: running_vms_fail_back="{{ ovirt_vms }}"
+
+  ignore_errors: "{{ dr_ignore_error_clean }}"
+- always:
+    - name: Revoke the SSO token
+      ovirt_auth:
+          state: absent
+          ovirt_auth: "{{ ovirt_auth }}"
+


### PR DESCRIPTION
Support DR with oVirt

This patch should add support for Disaster Recovery with oVirt
using an ansible tool which can recover and clean the oVirt setup.

The current script supports ansible latest master (v2.5 future
release)
The SDK version this script is based on is
   python-ovirt-engine-sdk4-4.2.1-1.a2.20171031git7f3b968.fc25.x86_64.rpm

To execute the DR, one can use the following command:
~/git/ansible/bin/ansible-playbook ~/ovirt-ansible/examples/dr_ovirt_setup.yml  --tags "fail_back" --ask-vault-pass -vvv

   {ansible_home}/bin/ansible-playbook ./ovirt-ansible/examples/dr_ovirt_setup.yml
        --extra-vars "target_host='primary'" --ask-vault-pass

Here is an example of the var file that should be used:

There are extra vars which can be configured as part of the dr support:
  target_host    - Indicates which host should the ansible script be executed (Optional values are primary and secondary).
  source_mapping - Indeicate the mapping which will be used to map each value of the entity registered in the target host.

Here are the following tags which are supported:
 - fail_back - Supports fail back scenrio from site at source map to the destination site mentioned in target_host
 - fail_over- Supports fail over scneario from site mentioned in target_host to site mentioned in source_map
 - clean_engine - Cleans the engine setup of the source_map
