### PR TITLE
Add new ovirt-host-deploy-facts role and use it in ovirt-host-deploy-firewalld role

### DIFF
--- a/roles/ovirt-host-deploy-facts/README.md
+++ b/roles/ovirt-host-deploy-facts/README.md
@@ -1,0 +1,37 @@
+oVirt host deploy - fatcs
+=============================
+
+This role is used to fetch specific information from oVirt hosts and create a facts.
+
+Requirements
+------------
+
+ * Ansible version 2.0
+
+Fatcs created
+-------------
+
+| Name                        | Description                                                       |
+|-----------------------------|-------------------------------------------------------------------|
+| host_deploy_vdsm_version    | Represent a result of running command "rpm -q --qf '%{version}' vdsm" on the host. |
+
+Dependencies
+------------
+
+No.
+
+Example Playbook
+----------------
+
+```yaml
+- name: oVirt host deploy - facts
+  hosts: hostname
+
+  roles:
+    - ovirt-host-deploy-facts
+```
+
+License
+-------
+
+Apache License 2.0

--- a/roles/ovirt-host-deploy-facts/meta/main.yml
+++ b/roles/ovirt-host-deploy-facts/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: Ondra Machacek
+  description: Role to fetch fatcs from oVirt host.
+  company: Red Hat, Inc.
+
+  license: Apache License 2.0
+
+  min_ansible_version: 2.0
+
+  platforms:
+  - name: EL
+    versions:
+    - 7
+
+  galaxy_tags: [ovirt, rhv, rhev, virtualization]
+
+dependencies: []

--- a/roles/ovirt-host-deploy-facts/tasks/main.yml
+++ b/roles/ovirt-host-deploy-facts/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Fetch info about VDSM
+  command: bash -c "rpm -q vdsm --qf '%{VERSION}'"
+  changed_when: false
+  register: vdsm_version
+
+- name: Set facts
+  set_fact:
+    host_deploy_vdsm_version: "{{ vdsm_version.stdout }}"

--- a/roles/ovirt-host-deploy-firewalld/tasks/main.yml
+++ b/roles/ovirt-host-deploy-firewalld/tasks/main.yml
@@ -1,15 +1,10 @@
 ---
-- name: Fetch info about VDSM
-  command: bash -c "rpm -q vdsm --qf '%{VERSION}'"
-  changed_when: false
-  register: vdsm_version
-
 - name: Check if VDSM version is supported for FirewallD
   fail:
-    msg: "VDSM version {{ vdsm_version.stdout }} is not supported for FirewallD."
+    msg: "VDSM version {{ host_deploy_vdsm_version }} is not supported for FirewallD."
   when:
     - "host_deploy_firewall_type == 'FIREWALLD'"
-    - "vdsm_version.stdout | version_compare('4.20', '<')"
+    - "host_deploy_vdsm_version | version_compare('4.20', '<')"
 
 - block:
     - name: Stop iptables service if running
@@ -68,4 +63,4 @@
   when:
     - "host_deploy_override_firewall"
     - "host_deploy_firewall_type == 'FIREWALLD'"
-    - "vdsm_version | version_compare('4.20', '>=')"
+    - "host_deploy_vdsm_version | version_compare('4.20', '>=')"

--- a/roles/ovirt-host-deploy/meta/main.yml
+++ b/roles/ovirt-host-deploy/meta/main.yml
@@ -18,4 +18,5 @@ galaxy_info:
   galaxy_tags: [ovirt, rhv, rhev, virtualization]
 
 dependencies:
+  - ovirt-host-deploy-facts
   - ovirt-host-deploy-firewalld


### PR DESCRIPTION
This PR add new ovirt-host-deploy-facts, which currently only fetches information about VDSM version from hosts and use this fact in ovirt-host-deploy-firewalld role.