### PR TITLE
Add YAML file to tell CI which distros to build

### DIFF
--- a/automation.yaml
+++ b/automation.yaml
@@ -1,0 +1,4 @@
+distros:
+  - fc25
+  - fc26
+  - el7


### PR DESCRIPTION
New CI jobs move (more of) the configuration from the `jenkins` repo to the individual project repos. So now this needs to be configured here instead of in the 'Jenkins' repo.