### PR TITLE
Add YAML file for CI (For 1.0 branch)

### DIFF
--- a/automation.yaml
+++ b/automation.yaml
@@ -1,0 +1,3 @@
+distros:
+  - fc24
+  - el7


### PR DESCRIPTION
New CI jobs move (more of) the configuration from the `jenkins` repo to the
individual project repos. So now this needs to be configured here instead of in
the `Jenkins` repo.

This commit is for the `ovirt-ansible-1.0` branch.