### PR TITLE
Add timeouts for ovirt-vm-infra role

### DIFF
--- a/roles/ovirt-vm-infra/README.md
+++ b/roles/ovirt-vm-infra/README.md
@@ -12,11 +12,17 @@ Requirements
 Role Variables
 --------------
 
-| Name               | Default value     |                                              |
-|--------------------|-------------------|----------------------------------------------| 
-| vms                | UNDEF             | List of dictionaries with virtual machine specifications.   |
-| wait_for_ip        | true              | If true, the playbook should wait for the virtual machine IP reported by the guest agent.  |
-| debug_vm_create    | false             | If true, logs the tasks of the virtual machine being created. The log can contain passwords. |
+| Name                           | Default value |                                              |
+|--------------------------------|---------------|----------------------------------------------| 
+| vms                            | UNDEF         | List of dictionaries with virtual machine specifications.   |
+| wait_for_ip                    | true          | If true, the playbook should wait for the virtual machine IP reported by the guest agent.  |
+| debug_vm_create                | false         | If true, logs the tasks of the virtual machine being created. The log can contain passwords. |
+| vm_infra_create_single_timeout | 180           | Time in seconds to wait for VM to be created and started (if state is running). |
+| vm_infra_create_poll_interval  | 15            | Polling interval. Time in seconds to wait between check of state of VM.  |
+| vm_infra_create_all_timeout    | vm_infra_create_single_timeout * (vms | length) | Total time to wait for all VMs to be created/started. |
+| vm_infra_wait_for_ip_retries   | 5             | Number of retries to check if VM is reporting it's IP address. |
+| vm_infra_wait_for_ip_delay     | 5             | Polling interval of IP address. Time in seconds to wait between check if VM reports IP address. |
+
 
 The `vms` list can contain following attributes:
 

--- a/roles/ovirt-vm-infra/defaults/main.yml
+++ b/roles/ovirt-vm-infra/defaults/main.yml
@@ -1,3 +1,12 @@
 ---
 debug_vm_create: false
 wait_for_ip: true
+
+# Create VMs timeouts:
+vm_infra_create_single_timeout: 180
+vm_infra_create_poll_interval: 15
+vm_infra_create_all_timeout: "{{ vm_infra_create_single_timeout * (vms | length)|int }}"
+
+# Wait for IPs timeouts:
+vm_infra_wait_for_ip_retries: 5
+vm_infra_wait_for_ip_delay: 5

--- a/roles/ovirt-vm-infra/tasks/main.yml
+++ b/roles/ovirt-vm-infra/tasks/main.yml
@@ -31,21 +31,22 @@
         root_password: "{{ item.profile.root_password | default(omit) }}"
       cloud_init_nics: "{{ item.profile.cloud_init_nics | default(omit) }}"
       nics: "{{ item.profile.nics | default(omit) }}"
+      timeout: "{{ vm_infra_create_single_timeout }}"
     with_items:
       - "{{ vms }}"
     changed_when: false
-    async: 800
+    async: "{{ vm_infra_create_all_timeout }}"
     poll: 0
     register: all_vms
-  
+
   - name: Wait for VMs to be added
     async_status: "jid={{ item.ansible_job_id }}"
     register: job_result
     with_items:
       - "{{ all_vms.results }}"
     until: job_result.finished
-    retries: 40
-    delay: 20
+    retries: "{{ (vm_infra_create_all_timeout|int / vm_infra_create_poll_interval) | round|int + 1  }}"
+    delay: "{{ vm_infra_create_poll_interval }}"
 
   - name: Manage VMs NICs
     ovirt_nics:
@@ -102,11 +103,11 @@
     with_items:
       - "{{ vms }}"
     until: ovirt_vms | map(attribute='reported_devices') | list | first | length > 0
-    retries: 5
-    delay: 5
+    retries: "{{ vm_infra_wait_for_ip_retries }}"
+    delay: "{{ vm_infra_wait_for_ip_delay }}"
     when:
       - "wait_for_ip"
-      - "item.profile.state != 'stopped'"
+      - "item.profile.state | default('present') != 'stopped'"
 
   always:
     - name: Logout from oVirt


### PR DESCRIPTION
Added new variables to manage timeouts:

 - Timeout to create single VM - `vm_infra_create_single_timeout`: 180
 - Timeout to poll creating of VM - `vm_infra_create_poll_interval`: 15
 - Timeout to wait to create all VMs - `vm_infra_create_all_timeout`: "{{ `vm_infra_create_single_timeout` * (`vms` | length) }}"
 - Timeout to retry check if VM reports IP - `vm_infra_wait_for_ip_retries`: 5
 - The delay between polling for IP report of VM - `vm_infra_wait_for_ip_delay`: 5

Related-to: https://bugzilla.redhat.com/show_bug.cgi?id=1490838