### PR TITLE
Improve reinstalling of the hosts

### DIFF
--- a/roles/ovirt-hosts/README.md
+++ b/roles/ovirt-hosts/README.md
@@ -14,15 +14,16 @@ Role Variables
 
 The `hosts` list can contain the following parameters:
 
-| Name          | Default value  | Description                           |
-|---------------|----------------|---------------------------------------|
-| name          | UNDEF          | Name of the host.                      |
-| state         | present        | Specifies whether the host is `present` or `absent`.  |
-| address       | UNDEF          | IP address or FQDN of the host.   |
-| password      | UNDEF          | The host's root password.             |
-| cluster       | UNDEF          | The cluster that the host must connect to.    |
-| timeout       | 1200           | Maximum wait time for the host to be in an UP state.  |
-| poll_interval | 20             | Polling interval to check the host status. |
+| Name          | Default value    | Description                           |
+|---------------|------------------|---------------------------------------|
+| name          | UNDEF (Required) | Name of the host.                      |
+| state         | present          | Specifies whether the host is `present` or `absent`.  |
+| address       | UNDEF (Required) | IP address or FQDN of the host.   |
+| password      | UNDEF            | The host's root password. Required if <i>public_key</i> is false. |
+| public_key    | UNDEF            | If <i>true</i> the public key should be used to authenticate to host. |
+| cluster       | UNDEF (Required) | The cluster that the host must connect to.    |
+| timeout       | 1200             | Maximum wait time for the host to be in an UP state.  |
+| poll_interval | 20               | Polling interval to check the host status. |
 
 Dependencies
 ------------

--- a/roles/ovirt-hosts/defaults/main.yml
+++ b/roles/ovirt-hosts/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+ovirt_hosts_max_timeout: 1500
+ovirt_hosts_add_timeout: 1200

--- a/roles/ovirt-hosts/tasks/main.yml
+++ b/roles/ovirt-hosts/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Get hosts
   ovirt_hosts_facts:
     auth: "{{ ovirt_auth }}"
-    pattern: "name=*"
+    pattern: "{{ hosts | map(attribute='name') | map('regex_replace', '(.*)', 'name=\\1') | list | join(' or ') }} status=installfailed"
   tags:
     - hosts
     - reinstall
@@ -12,9 +12,10 @@
     auth: "{{ ovirt_auth }}"
     state: reinstalled
     name: "{{ item.name }}"
+    public_key: "{{ item.password is undefined }}"
+    password: "{{ item.password | default(omit) }}"
   with_items:
     - "{{ ovirt_hosts | default([]) }}"
-  when: item.status == 'install_failed'
   tags:
     - hosts
     - reinstall
@@ -25,14 +26,15 @@
     state: "{{ item.state | default(omit) }}"
     name: "{{ item.name }}"
     address: "{{ item.address }}"
-    password: "{{ item.password }}"
     cluster: "{{ item.cluster }}"
+    password: "{{ item.password | default(omit) }}"
+    public_key: "{{ item.public_key | default(omit) }}"
     override_iptables: true
-    timeout: "{{ item.timeout | default(1200) }}"
+    timeout: "{{ item.timeout | default(ovirt_hosts_add_timeout) }}"
     poll_interval: "{{ item.poll_interval | default(20) }}"
   with_items:
     - "{{ hosts | default([]) }}"
-  async: 1200
+  async: "{{ ovirt_hosts_max_timeout }}"
   poll: 0
   register: add_hosts
   tags:
@@ -46,5 +48,5 @@
   tags:
     - hosts
   until: job_result.finished
-  retries: 120
+  retries: "{{ ovirt_hosts_max_timeout // 20 }}"
   delay: 20


### PR DESCRIPTION
This patch improve the reinstalling of the host:

 - support to pass also public key instead of password
 - improve the search, so we search only for host in install_failed state and
   only hosts we specified in variables
 - document the timeouts