### PR TITLE
ovirt-aaa-jdbc: allow set attributes for user

### DIFF
--- a/roles/ovirt-aaa-jdbc/README.md
+++ b/roles/ovirt-aaa-jdbc/README.md
@@ -20,6 +20,7 @@ The items in `users` list can contain the following parameters:
 | authz_name    | UNDEF          | Authorization provider of the user.    |
 | password      | UNDEF          | Password of the user.                  |
 | valid_to      | UNDEF          | Specifies the date that the account remains valid. |
+| attributes    | UNDEF          | A dict of attributes related to the user. Available attributes: <ul><li>department</li><li>description</li><li>displayName</li><li>email</li><li>firstName</li><li>lasName</li><li>title</li></ul>|
 
 The items in `user_groups` list can contain the following parameters:
 
@@ -54,6 +55,9 @@ Example Playbook
        authz_name: internal-authz
        password: 1234568
        valid_to: "2018-01-01 00:00:00Z"
+       attributes:
+         firstName: 'alice'
+         department: 'Quality Engineering'
     
     user_groups:
      - name: group1

--- a/roles/ovirt-aaa-jdbc/tasks/main.yml
+++ b/roles/ovirt-aaa-jdbc/tasks/main.yml
@@ -16,6 +16,21 @@
     - ovirt-aaa-jdbc
     - users
 
+- name: Update users according to attributes
+  command: "{{ aaa_jdbc_prefix }}/ovirt-aaa-jdbc-tool user edit {{ item.name }} {% for attr, value in item['attributes'].iteritems() %} --attribute={{ attr }}='{{ value }}' {% endfor %}"
+  with_items:
+    - "{{ users | default([]) }}"
+  register: out_users
+  when: "item.attributes is defined"
+  changed_when: "out_users.rc != 5 and out_users.rc != 4"
+  # 5 == user already exists
+  # 4 == no user to be removed
+  # 0 == all OK
+  failed_when: "out_users.rc != 5 and out_users.rc != 0 and out_users.rc != 4"
+  tags:
+    - ovirt-aaa-jdbc
+    - users
+
 # FIXME: when user try to change the password which was already set in history
 # but is not current password we continue with changed=false:
 - name: Manage internal users passwords


### PR DESCRIPTION
When you add a user via ovirt-aaa-jdbc you can set attributes with
```
--attribute=[<name>=<value>]
    Available names:
      department
      description
      displayName
      email
      firstName
      lastName
      title
```

Example of how to send these variables in a playbook:
```yaml
vars:
  users:
    - name: user1
      authz_name: internal-authz
      password: 1234568
      valid_to: "2018-01-01 00:00:00Z"
    - name: user2
      authz_name: internal-authz
      password: 1234568
      valid_to: "2018-01-01 00:00:00Z"
      attributes:
        firstName: 'alice'
        department: 'Quality Engineering'
```

Fixes: https://github.com/oVirt/ovirt-ansible/issues/48