### PR TITLE
Fix the flow of the ovirt-vm-infra role

### DIFF
--- a/roles/ovirt-vm-infra/tasks/create_vms.yml
+++ b/roles/ovirt-vm-infra/tasks/create_vms.yml
@@ -1,0 +1,27 @@
+- name: "Get info about VM {{current_vm.name }}"
+  ovirt_vms_facts:
+    auth: "{{ ovirt_auth }}"
+    pattern: "name={{ current_vm.name }}"
+
+- name: "Create VM {{current_vm.name }}"
+  no_log: "{{ not debug_vm_create }}"
+  ovirt_vms:
+    auth: "{{ ovirt_auth }}"
+    state: "{{ (ovirt_vms | length > 0) | ternary(current_vm.profile.state | default(omit), 'stopped') }}"
+    name: "{{ current_vm.name }}"
+    cluster: "{{ current_vm.profile.cluster | default(omit) }}"
+    template: "{{ current_vm.profile.template | default(omit) }}"
+    memory: "{{ current_vm.profile.memory | default(omit) }}"
+    cpu_cores: "{{ current_vm.profile.cores | default(omit) }}"
+    memory_guaranteed: "{{ current_vm.profile.memory_guaranteed | default(omit) }}"
+    cpu_sockets: "{{ current_vm.profile.sockets | default(omit) }}"
+    high_availability: "{{ current_vm.profile.high_availability | default(omit) }}"
+    storage_domain: "{{ current_vm.profile.storage_domain | default(omit) }}"
+    timeout: "{{ vm_infra_create_single_timeout }}"
+  changed_when: false
+  async: "{{ vm_infra_create_single_timeout }}"
+  poll: 0
+  register: added_vm
+
+- set_fact:
+    all_vms: "{{ all_vms | default([]) + [added_vm] }}"

--- a/roles/ovirt-vm-infra/tasks/main.yml
+++ b/roles/ovirt-vm-infra/tasks/main.yml
@@ -11,44 +11,37 @@
     register: loggedin
 
   - name: Create VMs
-    no_log: "{{ not debug_vm_create }}"
-    ovirt_vms:
-      auth: "{{ ovirt_auth }}"
-      state: "{{ item.profile.state | default(omit) }}"
-      name: "{{ item.name }}"
-      cluster: "{{ item.profile.cluster | default(omit) }}"
-      template: "{{ item.profile.template | default(omit) }}"
-      memory: "{{ item.profile.memory | default(omit) }}"
-      cpu_cores: "{{ item.profile.cores | default(omit) }}"
-      memory_guaranteed: "{{ item.profile.memory_guaranteed | default(omit) }}"
-      cpu_sockets: "{{ item.profile.sockets | default(omit) }}"
-      high_availability: "{{ item.profile.high_availability | default(omit) }}"
-      storage_domain: "{{ item.profile.storage_domain | default(omit) }}"
-      cloud_init:
-        host_name: "{{ item.name }}.{{ item.profile.domain | default(omit) }}"
-        authorized_ssh_keys: "{{ item.profile.ssh_key | default('') }}"
-        user_name: root
-        root_password: "{{ item.profile.root_password | default(omit) }}"
-      cloud_init_nics: "{{ item.profile.cloud_init_nics | default(omit) }}"
-      nics: "{{ item.profile.nics | default(omit) }}"
-      timeout: "{{ vm_infra_create_single_timeout }}"
-    with_items:
-      - "{{ vms }}"
-    changed_when: false
-    async: "{{ vm_infra_create_all_timeout }}"
-    poll: 0
-    register: all_vms
+    include: create_vms.yml
+    with_items: "{{ vms }}"
+    loop_control:
+      loop_var: "current_vm"
 
   - name: Wait for VMs to be added
     async_status: "jid={{ item.ansible_job_id }}"
     register: job_result
-    with_items:
-      - "{{ all_vms.results }}"
+    with_items: "{{ all_vms }}"
     until: job_result.finished
-    retries: "{{ (vm_infra_create_all_timeout|int / vm_infra_create_poll_interval) | round|int + 1  }}"
+    retries: "{{ (vm_infra_create_all_timeout|int // vm_infra_create_poll_interval) + 1  }}"
     delay: "{{ vm_infra_create_poll_interval }}"
 
-  - name: Manage VMs NICs
+  - name: Manage disks
+    ovirt_disks:
+      auth: "{{ ovirt_auth }}"
+      name: "{{ item.0.name }}_{{ item.1.name }}"
+      vm_name: "{{ item.0.name }}"
+      size: "{{ item.1.size | default(omit) }}"
+      format: "{{ item.1.format | default(omit) }}"
+      storage_domain: "{{ item.1.storage_domain | default(omit) }}"
+      interface: "{{ item.1.interface | default(omit) }}"
+      bootable: "{{ item.1.bootable | default(omit) }}"
+      wait: true
+    with_subelements:
+      - "{{ vms }}"
+      - "profile.disks"
+      - flags:
+        skip_missing: true
+  
+  - name: Manage NICs
     ovirt_nics:
       auth: "{{ ovirt_auth }}"
       vm: "{{ item.0.name }}"
@@ -59,26 +52,37 @@
       network: "{{ item.1.network | default(omit) }}" 
     with_subelements:
       - "{{ vms }}"
-      - profile.nics
+      - "profile.nics"
       - flags:
-        skip_missing: True
-
-  - name: Create VMs disks
-    ovirt_disks:
-      auth: "{{ ovirt_auth }}"
-      name: "{{ item.0.name }}_{{ item.1.name }}"
-      vm_name: "{{ item.0.name }}"
-      size: "{{ item.1.size | default(omit) }}"
-      format: "{{ item.1.format | default('cow') }}"
-      interface: "{{ item.1.interface | default(omit) }}"
-      bootable: "{{ item.1.bootable | default(omit) }}"
-      storage_domain: "{{ item.1.storage_domain | default(omit) }}"
-    with_subelements:
-      - "{{ vms }}"
-      - profile.disks
-      - flags:
-        skip_missing: True
+        skip_missing: true
   
+  - name: Manage state
+    ovirt_vms:
+      auth: "{{ ovirt_auth }}"
+      state: "{{ item.profile.state | default(omit) }}"
+      name: "{{ item.name }}"
+      cloud_init:
+        host_name: "{{ item.name }}.{{ item.profile.domain | default(omit) }}"
+        authorized_ssh_keys: "{{ item.profile.ssh_key | default('') }}"
+        user_name: root
+        root_password: "{{ item.profile.root_password | default(omit) }}"
+      cloud_init_nics: "{{ item.profile.cloud_init_nics | default(omit) }}"
+      timeout: "{{ vm_infra_create_single_timeout }}"
+    with_items: "{{ vms }}"
+    changed_when: false
+    async: "{{ vm_infra_create_all_timeout }}"
+    poll: 0
+    register: all_vms
+
+  - name: Wait for VMs state
+    async_status: "jid={{ item.ansible_job_id }}"
+    register: job_result
+    with_items:
+      - "{{ all_vms.results }}"
+    until: job_result.finished
+    retries: "{{ (vm_infra_create_all_timeout|int // vm_infra_create_poll_interval) + 1  }}"
+    delay: "{{ vm_infra_create_poll_interval }}"
+
   - name: Tag VMs
     ovirt_tags:
       auth: "{{ ovirt_auth }}"


### PR DESCRIPTION
This patch changes the flow of the tasks in the ovirt-vm-infra role. We
need to first create a stopped VM, then attache the needed disks/nics,
and later start the VM if needed.
    
If VM is already started prior to this role, we try to hotplug disks and
nics.
    
Related-to: https://bugzilla.redhat.com/show_bug.cgi?id=1490930