### PR TITLE
Add cloud_init parameter to VM

### DIFF
--- a/roles/ovirt-vm-infra/README.md
+++ b/roles/ovirt-vm-infra/README.md
@@ -30,6 +30,8 @@ The `vms` list can contain following attributes:
 |--------------------|-----------------------|--------------------------------------------| 
 | name               | UNDEF                 | Name of the virtual machine to create.     |
 | tag                | UNDEF                 | Name of the tag to assign to the virtual machine.  |
+| cloud_init         | UNDEF                 | Dictionary with values for Unix-like Virtual Machine initialization using cloud init. |
+| cloud_init_nics    | UNDEF                 | List of dictionaries representing network interafaces to be setup by cloud init. See below for more detailed description. |
 | profile            | UNDEF                 | Dictionary specifying the virtual machine hardware. See the table below.  |
 
 The `profile` dictionary can contain following attributes:
@@ -44,13 +46,19 @@ The `profile` dictionary can contain following attributes:
 | sockets            | UNDEF                 | Number of virtual CPUs sockets of the Virtual Machine.  |
 | disks              | UNDEF                 | Dictionary specifying the additional virtual machine disks. See below for more detailed description. |
 | nics               | UNDEF                 | List of dictionaries specifying the NICs of the virtual machine. See below for more detailed description.   |
-| ssh_key            | UNDEF                 | SSH key to be deployed to the virtual machine.                 |
-| domain             | UNDEF                 | The domain of the virtual machine.                         |
-| root_password      | UNDEF                 | The root password of the virtual machine.                      |
-| cloud_init_nics    | UNDEF                 | List of dictionaries representing network interafaces to be setup by cloud init. See below for more detailed description. |
 | high_availability  | UNDEF                 | Whether or not the node should be set highly available. |
 | storage_domain     | UNDEF                 | Name of the storage domain where all virtual machine disks should be created. Considered only when template is provided.|
 | state              | present               | Should the Virtual Machine be stopped, present or running.|
+
+Following attributes of `profile` dictionary are deprecated and will be removed in ovirt-ansible-roles version 1.1,
+please use `cloud_init` parameter instead. Those parameters has precedence before `cloud_init` parameter to not
+break backward compatibility, so please remove them when using `cloud_init`.
+
+| Name               | Default value         |                                               |
+|--------------------|-----------------------|-----------------------------------------------|
+| ssh_key            | UNDEF                 | SSH key to be deployed to the virtual machine.|
+| domain             | UNDEF                 | The domain of the virtual machine.            |
+| root_password      | UNDEF                 | The root password of the virtual machine.     |
 
 The item in `disks` list of `profile` dictionary can contain following attributes:
 
@@ -60,27 +68,24 @@ The item in `disks` list of `profile` dictionary can contain following attribute
 | name               | UNDEF          | The name of the additional disk.  |
 | storage_domain     | UNDEF          | The name of storage domain where disk should be created. |
 | interface          | UNDEF          | The interface of the disk. |
+| format             | UNDEF          | Specify format of the disk.  <ul><li>cow - If set, the disk will by created as sparse disk, so space will be allocated for the volume as needed. This format is also known as thin provisioned disks</li><li>raw - If set, disk space will be allocated right away. This format is also known as preallocated disks.</li></ul> |
+| bootable           | UNDEF          | True if the disk should be bootable. |
 
 The item in `nics` list of `profile` dictionary can contain following attributes:
 
-| Name           | Default value  |                                              |
-|----------------|----------------|----------------------------------------------| 
-| name           | UNDEF          | Name of the NIC. |
-| profile_name   | UNDEF          | Profile name where NIC should be attached. |
-| interface      | UNDEF          | Type of the network interface. One of following: virtio, e1000, rtl8139, default is virtio. |
-| mac_address    | UNDEF          | Custom MAC address of the network interface, by default it's obtained from MAC pool. |
-| network        | UNDEF          | Logical network to which the VM network interface should use, by default Empty network is used if network is not specified. |
-
-The item in `cloud_init_nics` list of `profile` dictionary can contain following attributes:
-
 | Name               | Default value  |                                              |
 |--------------------|----------------|----------------------------------------------| 
-| nic_boot_protocol  | UNDEF          | Set boot protocol of the network interface of Virtual Machine. Can be one of none, dhcp or static. |
-| nic_ip_address     | UNDEF          | If boot protocol is static, set this IP address to network interface of Virtual Machine.
-| nic_netmask        | UNDEF          | If boot protocol is static, set this netmask to network interface of Virtual Machine.
-| nic_gateway        | UNDEF          | If boot protocol is static, set this gateway to network interface of Virtual Machine.
-| nic_name           | UNDEF          | Set name to network interface of Virtual Machine.
-| nic_on_boot        | UNDEF          | If True network interface will be set to start on boot.
+| name               | UNDEF          | The name of the network interface.           |
+| interface          | UNDEF          | Type of the network interface.               |
+| mac_address        | UNDEF          | Custom MAC address of the network interface, by default it's obtained from MAC pool. |
+| network            | UNDEF          | Logical network which the VM network interface should use. If network is not specified, then Empty network is used. |
+| profile            | UNDEF          | Virtual network interface profile to be attached to VM network interface. |
+
+The item in `cloud_init` dictionary can contain all parameters documented
+in upstream Ansible documentation of [ovirt_vms](http://docs.ansible.com/ansible/latest/ovirt_vms_module.html) module.
+
+The item in `cloud_init_nics` list can contain all parameters documented
+in upstream Ansible documentation of [ovirt_vms](http://docs.ansible.com/ansible/latest/ovirt_vms_module.html) module.
 
 Dependencies
 ------------

--- a/roles/ovirt-vm-infra/tasks/create_vms.yml
+++ b/roles/ovirt-vm-infra/tasks/create_vms.yml
@@ -4,7 +4,6 @@
     pattern: "name={{ current_vm.name }}"
 
 - name: "Create VM {{current_vm.name }}"
-  no_log: "{{ not debug_vm_create }}"
   ovirt_vms:
     auth: "{{ ovirt_auth }}"
     state: "{{ (ovirt_vms | length > 0) | ternary(current_vm.profile.state | default(omit), 'stopped') }}"

--- a/roles/ovirt-vm-infra/tasks/main.yml
+++ b/roles/ovirt-vm-infra/tasks/main.yml
@@ -48,37 +48,25 @@
       name: "{{ item.1.name | default(omit) }}"
       interface: "{{ item.1.interface | default(omit) }}"
       mac_address: "{{ item.1.mac_address | default(omit) }}"
-      profile: "{{ item.1.profile_name | default(omit) }}"
+      profile: "{{ item.1.profile | default(omit) }}"
       network: "{{ item.1.network | default(omit) }}" 
     with_subelements:
       - "{{ vms }}"
       - "profile.nics"
       - flags:
         skip_missing: true
-  
-  - name: Manage state
-    ovirt_vms:
-      auth: "{{ ovirt_auth }}"
-      state: "{{ item.profile.state | default(omit) }}"
-      name: "{{ item.name }}"
-      cloud_init:
-        host_name: "{{ item.name }}.{{ item.profile.domain | default(omit) }}"
-        authorized_ssh_keys: "{{ item.profile.ssh_key | default('') }}"
-        user_name: root
-        root_password: "{{ item.profile.root_password | default(omit) }}"
-      cloud_init_nics: "{{ item.profile.cloud_init_nics | default(omit) }}"
-      timeout: "{{ vm_infra_create_single_timeout }}"
-    with_items: "{{ vms }}"
-    changed_when: false
-    async: "{{ vm_infra_create_all_timeout }}"
-    poll: 0
-    register: all_vms
 
-  - name: Wait for VMs state
+  - name: Manage VMs state
+    include: manage_state.yml
+    with_items: "{{ vms }}"
+    loop_control:
+      loop_var: "current_vm"
+
+  - name: Wait for VMs to be started
+    no_log: "{{ not debug_vm_create }}"
     async_status: "jid={{ item.ansible_job_id }}"
     register: job_result
-    with_items:
-      - "{{ all_vms.results }}"
+    with_items: "{{ started_vms }}"
     until: job_result.finished
     retries: "{{ (vm_infra_create_all_timeout|int // vm_infra_create_poll_interval) + 1  }}"
     delay: "{{ vm_infra_create_poll_interval }}"

--- a/roles/ovirt-vm-infra/tasks/manage_state.yml
+++ b/roles/ovirt-vm-infra/tasks/manage_state.yml
@@ -1,0 +1,40 @@
+# To keep legacy cloud init parameters we need this:
+- name: Manage state
+  ovirt_vms:
+    auth: "{{ ovirt_auth }}"
+    state: "{{ current_vm.profile.state | default(omit) }}"
+    name: "{{ current_vm.name }}"
+    cloud_init:
+      host_name: "{{ current_vm.name }}.{{ current_vm.profile.domain | default(omit) }}"
+      authorized_ssh_keys: "{{ current_vm.profile.ssh_key | default('') }}"
+      user_name: "{{ current_vm.profile.root_password is defined | ternary('root', omit) }}"
+      root_password: "{{ current_vm.profile.root_password | default(omit) }}"
+    cloud_init_nics: "{{ current_vm.cloud_init_nics | default(omit) }}"
+    timeout: "{{ vm_infra_create_single_timeout }}"
+  changed_when: false
+  async: "{{ vm_infra_create_single_timeout }}"
+  poll: 0
+  register: legacy_started_vm
+  when: current_vm.profile.root_password is defined or current_vm.profile.domain is defined or current_vm.profile.ssh_key is defined
+
+- set_fact:
+    started_vms: "{{ started_vms|default([]) + [legacy_started_vm] }}"
+  when: not (legacy_started_vm.skipped | default(false))
+
+- name: Manage state
+  ovirt_vms:
+    auth: "{{ ovirt_auth }}"
+    state: "{{ current_vm.profile.state | default(omit) }}"
+    name: "{{ current_vm.name }}"
+    cloud_init: "{{ current_vm.cloud_init | default(omit) }}"
+    cloud_init_nics: "{{ current_vm.cloud_init_nics | default(omit) }}"
+    timeout: "{{ vm_infra_create_single_timeout }}"
+  changed_when: false
+  async: "{{ vm_infra_create_single_timeout }}"
+  poll: 0
+  register: started_vm
+  when: (current_vm.cloud_init is defined) or legacy_started_vm.skipped | default(false)
+
+- set_fact:
+    started_vms: "{{ started_vms|default([]) + [started_vm] }}"
+  when: not (started_vm.skipped | default(false))


### PR DESCRIPTION
This patch add new cloud init parameter to VM and deprecate the `domain`, `root_password` and `ssh_key`. This new parameter add flexibility to specify any cloud_init parameter which is supported by `ovirt_vms` module.