### PR TITLE
Skip ovn role if ovn_central var isn't specified

### DIFF
--- a/roles/ovirt-provider-ovn-driver/defaults/main.yml
+++ b/roles/ovirt-provider-ovn-driver/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 ovn_engine_cluster_version: "{{ host_deploy_cluster_version | default('4.2') }}"
-ovn_central: "{{ host_deploy_ovn_central }}"
+ovn_central: "{{ host_deploy_ovn_central | default(omit) }}"
 ovn_tunneling_network: "{{ host_deploy_ovn_tunneling_network | default('ovirtmgmt') }}"


### PR DESCRIPTION
In case user don't specify `host_deploy_ovn_central` or `ovn_central` we need to skip whole ovn role rather then fail, that it's not specified.