### PR TITLE
Add host-upgrade role

### DIFF
--- a/playbooks/ovirt-host-upgrade.yml
+++ b/playbooks/ovirt-host-upgrade.yml
@@ -1,0 +1,6 @@
+- hosts: all
+  remote_user: root
+  gather_facts: false
+
+  roles:
+    - ovirt-host-upgrade

--- a/roles/ovirt-host-upgrade/README.md
+++ b/roles/ovirt-host-upgrade/README.md
@@ -1,0 +1,37 @@
+oVirt Host Upgrade
+==================
+
+The `ovirt-host-upgrade` role updates all packages on the host and installs ovirt-host package if it isn't installed.
+
+Requirements
+------------
+
+ * Ansible version 2.0
+
+Role Variables
+--------------
+
+No.
+
+Dependencies
+------------
+
+No.
+
+Example Playbook
+----------------
+
+```yaml
+---
+- name: oVirt Host Upgrade
+  hosts: myhost1
+  gather_facts: false
+
+  roles:
+    - ovirt-host-upgrade
+```
+
+License
+-------
+
+Apache License 2.0

--- a/roles/ovirt-host-upgrade/callback_plugins/hostupgradeplugin.py
+++ b/roles/ovirt-host-upgrade/callback_plugins/hostupgradeplugin.py
@@ -1,0 +1,37 @@
+from __future__ import absolute_import
+__metaclass__ = type
+
+import json
+
+from ansible.plugins.callback import CallbackBase
+
+
+class CallbackModule(CallbackBase):
+    """
+    This callback module print list of packages which yum module report to be
+    updated. It checks only tasks with are tagged by 'updatecheck' tag.
+    """
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'stdout'
+    CALLBACK_NAME = 'hostupgradeplugin'
+
+    FETCH_PACKAGES_WITH_TAG = 'updatecheck'
+
+    def __init__(self, display=None):
+        super(CallbackModule, self).__init__(display)
+        self.packages = []
+
+    def v2_runner_on_ok(self, result, **kwargs):
+        if self.FETCH_PACKAGES_WITH_TAG in result._task.tags:
+            changes = result._result.get('changes', dict())
+            self.packages.extend(changes.get('installed', []))
+            self.packages.extend([
+                pkg[0] for pkg in changes.get('updated', [])
+            ])
+
+    def v2_playbook_on_stats(self, stats):
+        self._display.display(json.dumps(self.packages))
+
+    v2_runner_on_failed = v2_runner_on_ok
+    v2_runner_on_unreachable = v2_runner_on_ok
+    v2_runner_on_skipped = v2_runner_on_ok

--- a/roles/ovirt-host-upgrade/meta/main.yml
+++ b/roles/ovirt-host-upgrade/meta/main.yml
@@ -1,0 +1,20 @@
+galaxy_info:
+  author: Ondra Machacek
+  description: Role to upgrade single host in oVirt/RHV.
+  company: Red Hat, Inc.
+
+  license: Apache License 2.0
+
+  min_ansible_version: 2.2
+
+  platforms:
+  - name: EL
+    versions:
+      - all
+  - name: Fedora
+    versions:
+      - all
+
+  galaxy_tags: [ovirt, rhv, rhev, virtualization]
+
+dependencies: []

--- a/roles/ovirt-host-upgrade/tasks/main.yml
+++ b/roles/ovirt-host-upgrade/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+# All tasks marked by tag 'updatecheck' will be used by callback plugin
+# 'hostupgradeplugin' to retrieve information about packages which 
+# that tasks installs or updates. So if you want to add any specific task
+# analazying packages to be updates/installed please tag it by 'updatecheck'
+# tag.
+
+- name: Install ovirt-host package if it isn't installed
+  yum:
+    name: ovirt-host
+    state: latest
+  tags:
+    - updatecheck
+
+- name: Update system
+  yum:
+    name: '*'
+    state: latest
+  tags:
+    - updatecheck


### PR DESCRIPTION
We update and check of the update of the host using single playbook called `ovirt-host-upgrade.yml`. This playbooks just executes the `ovirt-host-upgrade` role. The difference between check-updated and update is following:

__Check-update__
 1. Run playbook with dry-mode (--check) and env variable `ANSIBLE_STDOUT_CALLBACK=hostupgradeplugin`.
 2. If any tasks tagged by `updatecheck` reports that there need to be installed/updated package `roles/ovirt-host-upgrade/callback_plugins/hostupgradeplugin.py` we save those packages and return list of all those packages.
 3. At the engine side we parse the stdout and save all packages that needs update.

__Update__
 1. Run playbook without dry-mode (--check) and default stdout callback plugin - so log stdout to ovirt-host-mgmt-ansible-*.log file.

Related-to: https://bugzilla.redhat.com/show_bug.cgi?id=1380498