### PR TITLE
Rename ovn_tunneling_network to ovn_tunneling_interface

### DIFF
--- a/roles/ovirt-provider-ovn-driver/README.md
+++ b/roles/ovirt-provider-ovn-driver/README.md
@@ -15,7 +15,7 @@ Role Variables
 |-----------------------------|----------------|-------------------------------------------------------------------|
 | ovn_engine_cluster_version<br/> alias: <i>host_deploy_cluster_version</i> | 4.2            | The version of the cluster where the host resides.  oVirt provider OVN driver is installed and configured on versions >= 4.2. |
 | ovn_central<br/> alias: <i>host_deploy_ovn_central</i>                    | UNDEF          | The IP address of the OVN Central host with OVN Southbound DB. If not set to an valid IP address oVirt provider OVN driver is not installed and configured. |
-| ovn_tunneling_network<br/> alias: <i>host_deploy_ovn_tunneling_network</i>        | ovirtmgmt      | The name of the physical logical network in engine, which will be used to create the OVN tunnels. |
+| ovn_tunneling_interface<br/> alias: <i>host_deploy_ovn_tunneling_interface</i>        | ovirtmgmt      | The host's IP address or the name of the logical network in engine, which will be used to create the OVN tunnels. |
 
 Dependencies
 ------------

--- a/roles/ovirt-provider-ovn-driver/defaults/main.yml
+++ b/roles/ovirt-provider-ovn-driver/defaults/main.yml
@@ -2,3 +2,4 @@
 ovn_engine_cluster_version: "{{ host_deploy_cluster_version | default('4.2') }}"
 ovn_central: "{{ host_deploy_ovn_central | default(omit) }}"
 ovn_tunneling_network: "{{ host_deploy_ovn_tunneling_network | default('ovirtmgmt') }}"
+ovn_tunneling_interface: "{{ host_deploy_ovn_tunneling_interface | default(ovn_tunneling_network) }}"

--- a/roles/ovirt-provider-ovn-driver/tasks/main.yml
+++ b/roles/ovirt-provider-ovn-driver/tasks/main.yml
@@ -19,7 +19,7 @@
 
   - name: Configure OVN for oVirt
     command: >
-        vdsm-tool ovn-config {{ ovn_central }} {{ ovn_tunneling_network }}
+        vdsm-tool ovn-config {{ ovn_central }} {{ ovn_tunneling_interface }}
 
   when:
     - ovn_central is defined


### PR DESCRIPTION
I am not brave enough to rename without keeping the old alias,
because this would break adding hosts.