### PR TITLE
Added release branch configuration

### DIFF
--- a/automation.yaml
+++ b/automation.yaml
@@ -2,3 +2,6 @@ distros:
   - fc25
   - fc26
   - el7
+release_branches:
+  master: ovirt-master
+  ovirt-ansible-1.0: ovirt-4.1


### PR DESCRIPTION
Added a mapping of the main release branches to oVirt change queues.

This makes the oVirt CI system automatically build changes pushed or
merged into those branches and push them into the specified change
queues for automated system testing and release.

The following change must be merged in oVirt Gerrit before this change
can be merged and take effect:
- https://gerrit.ovirt.org/c/82786/