### PR TITLE
ovirt-datacenters: Add option to cleanup dc which contains hosted engine VM

### DIFF
--- a/roles/ovirt-datacenter-cleanup/README.md
+++ b/roles/ovirt-datacenter-cleanup/README.md
@@ -4,6 +4,16 @@ oVirt Datacenter Cleanup
 The `ovirt-datacenter-cleanup` role is used to cleanup all entities inside
 oVirt datacenters and finally remove the datacenters themselves.
 
+In the special case that the datacenter provided to cleanup contains a VM that
+serves as Hosted Engine the role will not delete the following entities:
+
+- the hosted engine VM itself
+- the storage domain on which the hosted engine VM resides
+- the master storage domain
+- the host and cluster which accomodate the hosted engine VM
+- the datacenter itself
+
+
 Requirements
 ------------
 
@@ -17,6 +27,7 @@ Role Variables
 |--------------------------|-----------------------|--------------------------------------|
 | data_center_name         | UNDEF                 | Name of the data center.             |
 | format_storages          | false                 | Whether role should format storages when removing them. |
+| hosted_engine_vm_name    | HostedEngine          | Name of the hosted engine VM. If VM with such name exists HE environment is assumed. |
 
 Dependencies
 ------------

--- a/roles/ovirt-datacenter-cleanup/defaults/main.yml
+++ b/roles/ovirt-datacenter-cleanup/defaults/main.yml
@@ -1,1 +1,2 @@
 format_storages: false
+hosted_engine_vm_name: HostedEngine

--- a/roles/ovirt-datacenter-cleanup/tasks/disks.yml
+++ b/roles/ovirt-datacenter-cleanup/tasks/disks.yml
@@ -9,6 +9,8 @@
     id: "{{ ovirt_item.id }}"
     auth: "{{ ovirt_auth }}"
   with_items: "{{ ovirt_disks }}"
-  when: ovirt_item.name != 'OVF_STORE'
+  when:
+    - ovirt_item.name != 'OVF_STORE'
+    - not hosted_engine or (ovirt_item.id != hosted_engine_vm_disk_id)
   loop_control:
     loop_var: ovirt_item

--- a/roles/ovirt-datacenter-cleanup/tasks/find_hosted_engine_details.yml
+++ b/roles/ovirt-datacenter-cleanup/tasks/find_hosted_engine_details.yml
@@ -1,0 +1,26 @@
+- name: Find existing VMs
+  ovirt_vms_facts:
+    auth: "{{ ovirt_auth }}"
+    pattern: "datacenter={{ data_center_name }} and name={{ hosted_engine_vm_name }}"
+    fetch_nested: true
+
+- name: Find HE info if HE
+  set_fact:
+    hosted_engine: "{{ ovirt_vms | length > 0 }}"
+
+- name: Find HE Storage Domain id if HE
+  block:
+    - name: Fetch disk info of HE VM
+      ovirt_disks_facts:
+        auth: "{{ ovirt_auth }}"
+        pattern: "datacenter={{ data_center_name }} and vm_names={{ hosted_engine_vm_name }}"
+
+    - name: Find HE disk id and storage domain id
+      set_fact:
+        hosted_engine_vm_disk_id: "{{ ovirt_disks[0].id }}"
+        hosted_engine_sd_id: "{{ ovirt_disks[0].storage_domains[0].id}}"
+
+    - name: Find cluster that contains the hosted engine VM
+      set_fact:
+        hosted_engine_cluster_id: "{{ ovirt_vms[0].cluster.id }}"
+  when: hosted_engine

--- a/roles/ovirt-datacenter-cleanup/tasks/main.yml
+++ b/roles/ovirt-datacenter-cleanup/tasks/main.yml
@@ -1,7 +1,10 @@
+- name: Find hosted engine details if HE
+  include: find_hosted_engine_details.yml
+
 - name: Remove VMPools
   include: vm_pools.yml
 
-- name: Remove VMs
+- name: Remove VMs (apart from hosted engine VM if HE)
   include: vms.yml
 
 - name: Remove Templates
@@ -15,22 +18,25 @@
     auth: "{{ ovirt_auth }}"
     pattern: "datacenter={{ data_center_name }}"
 
-- name: Remove all Storage Domains except master
+- name: Remove all Storage Domains except master (and hosted_storage if HE)
   include: storages_pre.yml
 
 - name: Find existing clusters in Datacenter
-  ovirt_clusters_facts:
+  ovirt_cluster_facts:
     auth: "{{ ovirt_auth }}"
     pattern: "datacenter={{ data_center_name }}"
 
 - name: Remove Datacenter
   include: datacenter.yml
+  when: not hosted_engine
 
 - name: Remove master Storage Domain
   include: storages_last.yml
+  when: not hosted_engine
 
 - name: Remove Clusters and Hosts
   include: cluster_and_hosts.yml
   with_items: "{{ ovirt_clusters }}"
   loop_control:
     loop_var: cluster_item
+  when: cluster_item.id != hosted_engine_cluster_id

--- a/roles/ovirt-datacenter-cleanup/tasks/storages_pre.yml
+++ b/roles/ovirt-datacenter-cleanup/tasks/storages_pre.yml
@@ -3,14 +3,16 @@
     auth: "{{ ovirt_auth }}"
     pattern: "datacenter={{ data_center_name }}"
 
-- name: Remove Storage Domains apart from master
+- name: Remove Storage Domains apart from master and hosted_engine storage (if HE is used)
   ovirt_storage_domains:
     state: absent
     id: "{{ ovirt_item.id }}"
     auth: "{{ ovirt_auth }}"
     format: "{{ format_storages }}"
   with_items: "{{ ovirt_storage_domains }}"
-  when: not ovirt_item.master
+  when:
+    - not ovirt_item.master
+    - not hosted_engine or ovirt_item.id != hosted_engine_sd_id
   loop_control:
     loop_var: ovirt_item
 
@@ -21,6 +23,8 @@
     data_center: "{{ data_center_name }}"
     auth: "{{ ovirt_auth }}"
   with_items: "{{ ovirt_storage_domains }}"
-  when: ovirt_item.master
+  when:
+    - ovirt_item.master
+    - not hosted_engine
   loop_control:
     loop_var: ovirt_item

--- a/roles/ovirt-datacenter-cleanup/tasks/vms.yml
+++ b/roles/ovirt-datacenter-cleanup/tasks/vms.yml
@@ -3,11 +3,13 @@
     auth: "{{ ovirt_auth }}"
     pattern: "datacenter={{ data_center_name }}"
 
-- name: Remove VMs
+- name: Remove all VMs apart from HE one if exists
   ovirt_vms:
     state: absent
     id: "{{ ovirt_item.id }}"
     auth: "{{ ovirt_auth }}"
   with_items: "{{ ovirt_vms }}"
+  when: not hosted_engine or
+        (ovirt_item.name != hosted_engine_vm_name)
   loop_control:
     loop_var: ovirt_item

--- a/roles/ovirt-datacenters/README.md
+++ b/roles/ovirt-datacenters/README.md
@@ -3,6 +3,10 @@ oVirt Datacenters
 
 The `ovirt-datacenters` role is used to set up or cleanup oVirt datacenters.
 
+In the special case of cleaning up oVirt datacenter that contains a Hosted Engine VM
+the behavior of the role is different and is explained in more detail in:
+[ovirt-datacenter-cleanup]: https://github.com/oVirt/ovirt-ansible/blob/master/roles/ovirt-datacenter-cleanup/README.md
+
 Requirements
 ------------
 
@@ -20,8 +24,10 @@ Role Variables
 | data_center_local        | false                 | Specify whether the data center is shared or local. |
 | compatibility_version    | UNDEF                 | Compatibility version of data center. |
 | data_center_state        | present               | Specify whether the datacenter should be present or absent. |
-| recursive_cleanup        | false                 | Specify whether to recursively remove all entities inside DC. Valid only when state == absent. |
-| format_storages          | false                 | Specify whether to format ALL the storages that are going to be removed as part of the DC. Valid only when data_center_state == absent and recursive_cleanup == true. |
+| recursive_cleanup        | false                 | Specify whether to recursively remove all entities inside DC. Valid only when I(state) == I(absent). |
+| format_storages          | false                 | Specify whether to format ALL the storages that are going to be removed as part of the DC. Valid only when I(data_center_state) == I(absent) and I(recursive_cleanup) == I(true). |
+| hosted_engine_vm_name    | HostedEngine          | Name of the hosted engine VM. If VM with such name exists HE environment is assumed. Valid only when I(data_center_state) == I(absent) and I(recursive_cleanup) == I(true). |
+
 
 Dependencies
 ------------


### PR DESCRIPTION
In this case of HE all entities that the hosted_engine VM relies on within the datacenter
will not be deleted.

Also fixed some deprecation warnings.