### PR TITLE
ovirt-vm-infra: Wait for IP address to appear

### DIFF
--- a/roles/ovirt-vm-infra/tasks/main.yml
+++ b/roles/ovirt-vm-infra/tasks/main.yml
@@ -85,7 +85,7 @@
   - name: Apply any Affinity Groups
     include_role:
       name: ovirt-affinity-groups
-  
+
   - name: Wait for VMs IP
     ovirt_vms_facts:
       auth: "{{ ovirt_auth }}"
@@ -94,9 +94,11 @@
       nested_attributes: ips
     with_items:
       - "{{ vms }}"
-    until: ovirt_vms | map(attribute='reported_devices') | list | first | length > 0
+    until: "ovirt_vms | first | json_query(query) | length > 0"
     retries: "{{ vm_infra_wait_for_ip_retries }}"
     delay: "{{ vm_infra_wait_for_ip_delay }}"
+    vars:
+      query: "reported_devices[*].ips[*].address"
     when:
       - "wait_for_ip"
       - "item.profile.state | default('present') != 'stopped'"


### PR DESCRIPTION
Previously we just waited for device to appear rather than waiting for
the actual IP to appear. This patch fixes it.