### PR TITLE
ovirt-host-upgrade: update cache

### DIFF
--- a/roles/ovirt-host-upgrade/tasks/main.yml
+++ b/roles/ovirt-host-upgrade/tasks/main.yml
@@ -9,6 +9,7 @@
   yum:
     name: ovirt-host
     state: latest
+    update_cache: yes
   tags:
     - updatecheck
 
@@ -16,5 +17,6 @@
   yum:
     name: '*'
     state: latest
+    update_cache: yes
   tags:
     - updatecheck


### PR DESCRIPTION
This patch adding a cache update before running check for upgrade or actual upgrade.