### PR TITLE
automation: Fix syntax of 'release_branches'

### DIFF
--- a/automation.yaml
+++ b/automation.yaml
@@ -3,6 +3,5 @@ distros:
   - fc26
   - el7
 release_branches:
-  master: ovirt-master
-  master: ovirt-4.2
+  master: [ "ovirt-master", "ovirt-4.2" ]
   ovirt-ansible-1.0: ovirt-4.1


### PR DESCRIPTION
'release_branches' were not properly specified, so builds were not
properly pushed into the 4.2 change-queue.