### PR TITLE
automation: drop distributions and branches that reached EOL

### DIFF
--- a/automation.yaml
+++ b/automation.yaml
@@ -1,7 +1,5 @@
 distros:
-  - fc27
   - fc28
   - el7
 release_branches:
   master: [ "ovirt-master", "ovirt-4.2" ]
-  ovirt-ansible-1.0: ovirt-4.1


### PR DESCRIPTION
Dropping 4.1 branch and fc27 since both reached EOL.