### PR TITLE
fix the shutdown_env repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ Currently we have implemented following Ansible roles:
 * [oVirt.cluster-upgrade] - easily upgrade your oVirt clusters, host by host.
 * [oVirt.disaster-recovery] - plan, failover and failback oVirt in Disaster Recovery scenarios.
 * [oVirt.engine-setup] - setup your oVirt Engine via Ansible.
-* [oVirt.hosted-engine-setup] - setup your oVirt Hosted-Engine via Ansible.
 * [oVirt.infra] - setup a complete oVirt setup (data centers, clusters, hosts, networks...) via this role.
 * [oVirt.image-template] - easily create VM templates (via Glance or QCOW2 download)
 * [oVirt.manageiq] - install and configure a ManageIQ (or CloudForms) VM appliance on your oVirt!
 * [oVirt.repositories] - set up the required oVirt repositories on your hosts.
 * [oVirt.vm-infra] - configure a complete VM setup (create and configure VMs and their properties)
 * [oVirt.v2v-conversion-host] - define a host as a target for VMware to oVirt migration.
-* [oVirt.shutdown-env] - shutdown the whole environment in a clean and ordered way.
+* [oVirt.hosted_engine_setup] - setup your oVirt Hosted-Engine via Ansible.
+* [oVirt.shutdown_env] - shutdown the whole environment in a clean and ordered way.
 
 ## Installing the oVirt Roles
 
@@ -162,5 +162,5 @@ After the ansible-playbook playbook completes you will have a new data center na
 [oVirt.engine-setup]: https://github.com/oVirt/ovirt-ansible-engine-setup/blob/master/README.md
 [oVirt.repositories]: https://github.com/oVirt/ovirt-ansible-repositories/blob/master/README.md
 [oVirt.v2v-conversion-host]: https://github.com/oVirt/ovirt-ansible-v2v-conversion-host/blob/master/README.md
-[oVirt.hosted-engine-setup]: https://github.com/oVirt/ovirt-ansible-hosted-engine-setup/blob/master/README.md
-[oVirt.shutdown-env]: https://github.com/oVirt/ovirt-ansible-shutdown-env/blob/master/README.md
+[oVirt.hosted_engine_setup]: https://github.com/oVirt/ovirt-ansible-hosted-engine-setup/blob/master/README.md
+[oVirt.shutdown_env]: https://github.com/oVirt/ovirt-ansible-shutdown-env/blob/master/README.md

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -25,4 +25,4 @@ dependencies:
  - ovirt.vm-infra
  - ovirt.v2v-conversion-host
  - ovirt.hosted_engine_setup
- - ovirt.shutdown-env
+ - ovirt.shutdown_env


### PR DESCRIPTION
also updated the related doc file.
without this PR we got the following error:
- downloading role 'shutdown-env', owned by ovirt
 [WARNING]: - ovirt.shutdown-env was NOT installed successfully: - sorry, ovirt.shutdown-env was not found on https://galaxy.ansible.com.
ERROR! - you can use --ignore-errors to skip failed roles and finish processing the list.